### PR TITLE
Fix localStorage colorUses bug

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,6 +54,7 @@ if (persistedSchedule) {
   const persistedScheduleState = initialScheduleState.merge({
     sections: persistedSchedule.sections,
     associatedClasses: persistedSchedule.associatedClasses,
+    colorUses: persistedSchedule.colorUses,
   });
   persistedState = fromJS({ schedule: persistedScheduleState });
 }
@@ -70,10 +71,11 @@ store.subscribe(() => {
   const schedule = {
     sections: state.getIn(['schedule', 'sections']),
     associatedClasses: state.getIn(['schedule', 'associatedClasses']),
+    colorUses: state.getIn(['schedule', 'colorUses']),
   };
   const scheduleState = JSON.stringify(schedule);
 
-  // Only set to localStorage if state we care about has changed for performance
+  // Only set to localStorage if state we care about has changed, for performance
   if (scheduleState !== previousScheduleState) {
     window.localStorage.setItem('schedule', scheduleState);
     previousScheduleState = scheduleState;


### PR DESCRIPTION
The schedule state save to localStorage included classes in the calendar, but not the colorUses part of the state, so adding classes, then reloading, then adding more classes would mess up the class colors. This fixes that.