### PR TITLE
Make z-index of preview classes higher than added classes

### DIFF
--- a/src/components/Calendar/AssociatedClass.js
+++ b/src/components/Calendar/AssociatedClass.js
@@ -23,7 +23,7 @@ export const styles = {
     width: ({ section }) => `${MAX_WIDTH_PERCENT * section.columnWidth}%`,
     backgroundColor: ({ section }) => section.color,
     overflow: 'hidden',
-    zIndex: 1,
+    zIndex: ({ isPreview }) => isPreview ? 2 : 1,
   },
   container: {
     margin: '3px',

--- a/src/components/Calendar/AssociatedClass.test.js
+++ b/src/components/Calendar/AssociatedClass.test.js
@@ -41,6 +41,14 @@ describe('dynamic styles', () => {
   it('correctly calculates width', () => {
     expect(styles.paper.width({ section })).toBe(`${MAX_WIDTH_PERCENT}%`);
   });
+
+  it('correctly sets zIndex to 1 when class is not preview', () => {
+    expect(styles.paper.zIndex({ isPreview: false })).toBe(1);
+  });
+
+  it('correctly sets zIndex to 2 when class is preview', () => {
+    expect(styles.paper.zIndex({ isPreview: true })).toBe(2);
+  });
 });
 
 describe('AssociatedClass', () => {

--- a/src/components/Calendar/CalendarSection.js
+++ b/src/components/Calendar/CalendarSection.js
@@ -25,7 +25,7 @@ export const styles = {
     backgroundColor: ({ section }) => section.color,
     overflow: 'hidden',
     cursor: 'pointer',
-    zIndex: 1,
+    zIndex: ({ isPreview }) => isPreview ? 2 : 1,
   },
   container: {
     margin: '3px',

--- a/src/components/Calendar/CalendarSection.test.js
+++ b/src/components/Calendar/CalendarSection.test.js
@@ -41,6 +41,14 @@ describe('CalendarSection', () => {
     it('correctly calculates width', () => {
       expect(styles.paper.width({ section })).toBe(`${MAX_WIDTH_PERCENT}%`);
     });
+
+    it('correctly sets zIndex to 1 when class is not preview', () => {
+      expect(styles.paper.zIndex({ isPreview: false })).toBe(1);
+    });
+
+    it('correctly sets zIndex to 2 when class is preview', () => {
+      expect(styles.paper.zIndex({ isPreview: true })).toBe(2);
+    });
   });
 
   it('renders correctly', () => {

--- a/src/components/Calendar/HourCell.js
+++ b/src/components/Calendar/HourCell.js
@@ -35,9 +35,10 @@ function HourCell({
           section={allSections.find(section => section.id === associatedClass.sectionId)}
         />
       ))}
-      {sectionPreview && <CalendarSection section={sectionPreview} />}
+      {sectionPreview && <CalendarSection section={sectionPreview} isPreview />}
       {associatedClassPreview && (
         <AssociatedClass
+          isPreview
           associatedClass={associatedClassPreview}
           section={allSectionPreviews[0]}
         />

--- a/src/components/Calendar/__snapshots__/HourCell.test.js.snap
+++ b/src/components/Calendar/__snapshots__/HourCell.test.js.snap
@@ -52,6 +52,7 @@ ShallowWrapper {
                 "type": "LAB",
               }
             }
+            isPreview={true}
             section={
               Object {
                 "id": "12345",
@@ -72,6 +73,7 @@ ShallowWrapper {
             "associatedClass": Object {
               "type": "LAB",
             },
+            "isPreview": true,
             "section": Object {
               "id": "12345",
             },
@@ -110,6 +112,7 @@ ShallowWrapper {
                   "type": "LAB",
                 }
               }
+              isPreview={true}
               section={
                 Object {
                   "id": "12345",
@@ -130,6 +133,7 @@ ShallowWrapper {
               "associatedClass": Object {
                 "type": "LAB",
               },
+              "isPreview": true,
               "section": Object {
                 "id": "12345",
               },
@@ -190,6 +194,7 @@ ShallowWrapper {
       "associatedClass": Object {
         "type": "LAB",
       },
+      "isPreview": true,
       "section": Object {
         "id": "12345",
       },
@@ -218,6 +223,7 @@ ShallowWrapper {
         "associatedClass": Object {
           "type": "LAB",
         },
+        "isPreview": true,
         "section": Object {
           "id": "12345",
         },
@@ -544,6 +550,7 @@ ShallowWrapper {
           Array [],
           Array [],
           <ForwardRef
+            isPreview={true}
             section={
               Object {
                 "id": "12345",
@@ -561,6 +568,7 @@ ShallowWrapper {
           "key": undefined,
           "nodeType": "function",
           "props": Object {
+            "isPreview": true,
             "section": Object {
               "id": "12345",
             },
@@ -594,6 +602,7 @@ ShallowWrapper {
             Array [],
             Array [],
             <ForwardRef
+              isPreview={true}
               section={
                 Object {
                   "id": "12345",
@@ -611,6 +620,7 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "function",
             "props": Object {
+              "isPreview": true,
               "section": Object {
                 "id": "12345",
               },
@@ -669,6 +679,7 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "function",
     "props": Object {
+      "isPreview": true,
       "section": Object {
         "id": "12345",
       },
@@ -694,6 +705,7 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "function",
       "props": Object {
+        "isPreview": true,
         "section": Object {
           "id": "12345",
         },


### PR DESCRIPTION
When you hover over a class to see its preview on the calendar and it happens to overlap with an already added class, the preview class will be seen on top. This is done by conditionally setting the z-index to one higher than a normal section if the section is a preview. Tests and snapshots have been updated appropriately.