### PR TITLE
Recalculate class widths on remove

### DIFF
--- a/src/components/Calendar/AssociatedClass.js
+++ b/src/components/Calendar/AssociatedClass.js
@@ -9,19 +9,19 @@ export const MAX_WIDTH_PERCENT = 97;
 export const styles = {
   paper: {
     position: 'absolute',
-    top: ({ section }) => {
-      const minute = section.event.start.minute;
+    top: ({ associatedClass }) => {
+      const minute = associatedClass.event.start.minute;
       const offset = Math.round(minute / 60 * 100);
       return `${offset}%`;
     },
-    left: ({ section }) => `${MAX_WIDTH_PERCENT * section.columnWidth * section.column}%`,
-    height: ({ section }) => {
-      const durationInHours = getDurationInHours(section.event);
+    left: ({ associatedClass }) => `${MAX_WIDTH_PERCENT * associatedClass.columnWidth * associatedClass.column}%`,
+    height: ({ associatedClass }) => {
+      const durationInHours = getDurationInHours(associatedClass.event);
       const heightInPercent = Math.round(durationInHours * 100);
       return `${heightInPercent}%`;
     },
-    width: ({ section }) => `${MAX_WIDTH_PERCENT * section.columnWidth}%`,
-    backgroundColor: ({ section }) => section.color,
+    width: ({ associatedClass }) => `${MAX_WIDTH_PERCENT * associatedClass.columnWidth}%`,
+    backgroundColor: ({ associatedClass }) => associatedClass.color,
     overflow: 'hidden',
     zIndex: ({ isPreview }) => isPreview ? 2 : 1,
   },

--- a/src/components/Calendar/AssociatedClass.test.js
+++ b/src/components/Calendar/AssociatedClass.test.js
@@ -19,27 +19,27 @@ describe('dynamic styles', () => {
   };
   const hour = 10;
   const color = 'some color';
-  const section = { event, color, column: 0, columnWidth: 1 };
+  const associatedClass = { event, color, column: 0, columnWidth: 1 };
 
   it('correctly calculates section card placement', () => {
-    expect(styles.paper.top({ hour, dow, section })).toBe('50%');
+    expect(styles.paper.top({ hour, dow, associatedClass })).toBe('50%');
   });
 
   it('correctly calculates section card height', () => {
     timeUtils.getDurationInHours.mockReturnValue(1);
-    expect(styles.paper.height({ section })).toBe('100%');
+    expect(styles.paper.height({ associatedClass })).toBe('100%');
   });
 
   it('correctly grabs the section background color', () => {
-    expect(styles.paper.backgroundColor({ section })).toBe(color);
+    expect(styles.paper.backgroundColor({ associatedClass })).toBe(color);
   });
 
   it('correctly calculates left offset', () => {
-    expect(styles.paper.left({ section })).toBe('0%');
+    expect(styles.paper.left({ associatedClass })).toBe('0%');
   });
 
   it('correctly calculates width', () => {
-    expect(styles.paper.width({ section })).toBe(`${MAX_WIDTH_PERCENT}%`);
+    expect(styles.paper.width({ associatedClass })).toBe(`${MAX_WIDTH_PERCENT}%`);
   });
 
   it('correctly sets zIndex to 1 when class is not preview', () => {

--- a/src/reducers/add-section-handler-helpers/prep-classes-for-calendar.js
+++ b/src/reducers/add-section-handler-helpers/prep-classes-for-calendar.js
@@ -1,0 +1,40 @@
+import assignConflictInfo from './assign-conflict-info';
+import assignColor from './assign-color';
+
+export default function prepClassesForCalendar(
+  sections, color, associatedClasses,
+) {
+  if (associatedClasses) {
+    const sectionsAndAssociatedClasses = sections.concat(associatedClasses);
+    const sectionsAndAssociatedClassesWithConflictInfo = assignConflictInfo(
+      sectionsAndAssociatedClasses,
+    );
+
+    const sectionsWithConflictInfo = sectionsAndAssociatedClassesWithConflictInfo.filter(
+      sectionOrAssociatedClass => sectionOrAssociatedClass.get('id'),
+    );
+    // Associated classes do not have an id field
+    const associatedClassesWithConflictInfo = sectionsAndAssociatedClassesWithConflictInfo.filter(
+      sectionOrAssociatedClass => !sectionOrAssociatedClass.get('id'),
+    );
+
+    // In the case of removing classes, assignColor will do nothing
+    const sectionsWithConflictInfoAndColor = assignColor(color, sectionsWithConflictInfo);
+    const associatedClassWithConfictInfoAndColor = assignColor(
+      color,
+      associatedClassesWithConflictInfo,
+    );
+
+    return {
+      sections: sectionsWithConflictInfoAndColor,
+      associatedClasses: associatedClassWithConfictInfoAndColor,
+    };
+  }
+
+  const sectionsWithConflictInfo = assignConflictInfo(sections);
+
+  // In the case of removing classes, assignColor will do nothing
+  const sectionsWithConflictInfoAndColor = assignColor(color, sectionsWithConflictInfo);
+
+  return { sections: sectionsWithConflictInfoAndColor };
+}

--- a/src/reducers/add-section-handler-helpers/prep-classes-for-calendar.test.js
+++ b/src/reducers/add-section-handler-helpers/prep-classes-for-calendar.test.js
@@ -1,0 +1,38 @@
+import { fromJS } from 'immutable';
+import prepClassesForCalendar from './prep-classes-for-calendar';
+import * as assignConflictInfo from './assign-conflict-info';
+import * as assignColor from './assign-color';
+
+jest.mock('./assign-conflict-info');
+jest.mock('./assign-color');
+
+describe('prepClassesForCalendar', () => {
+  beforeEach(() => {
+    assignConflictInfo.default = jest.fn();
+    assignConflictInfo.default.mockImplementation(mockSections => mockSections);
+
+    assignColor.default = jest.fn();
+    assignColor.default.mockImplementation((mockColor, mockSections) => mockSections);
+  });
+
+  it('correctly preps sections', () => {
+    const sections = fromJS([{ id: '12345' }]);
+    const color = 'some color';
+
+    expect(prepClassesForCalendar(sections, color)).toEqual({ sections });
+    expect(assignConflictInfo.default).toHaveBeenCalled();
+    expect(assignColor.default).toHaveBeenCalled();
+  });
+
+  it('correctly preps sections and associated classes', () => {
+    const sections = fromJS([{ id: '12345' }]);
+    const associatedClasses = fromJS([{ sectionId: '12345' }]);
+    const color = 'some color';
+
+    expect(prepClassesForCalendar(sections, color, associatedClasses)).toEqual(
+      { sections, associatedClasses },
+    );
+    expect(assignConflictInfo.default).toHaveBeenCalled();
+    expect(assignColor.default).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
When a class was removed, the widths of all conflicting classes were not being recalculated. This now fixes that, so all conflicting class widths will readjust on class removal.

This was done through a refactor of all conflict/width related calculation and color assignation (basically everything you need to do to a section or an associated class to prep it for adding to the schedule) being put into one function (prepClassesForCalendar) that can be called when a class or an associated class is being added or removed.