### PR TITLE
Handle associated class edge case

### DIFF
--- a/src/components/Sidebar/common/SectionResult.js
+++ b/src/components/Sidebar/common/SectionResult.js
@@ -4,7 +4,7 @@ import { withStyles } from '@material-ui/styles';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
-import { getFormattedClassSchedule } from 'util/time';
+import { getFormattedClassSchedule, isUnscheduled } from 'util/time';
 
 export const styles = {
   sectionTitle: {
@@ -13,9 +13,8 @@ export const styles = {
 };
 
 function SectionResult({ addSection, sectionHover, sectionHoverOff, section, disabled, classes }) {
-  const isUnscheduled = section.schedule.some(
-    schedule => schedule.dow === 'TBA' || schedule.start === 'TBA' || schedule.end === 'TBA',
-  );
+  const sectionIsUnscheduled = section.schedule.some(isUnscheduled);
+
   return (
     <ListItem
       key={section.id}
@@ -23,7 +22,7 @@ function SectionResult({ addSection, sectionHover, sectionHoverOff, section, dis
       onClick={() => addSection(section)}
       onMouseEnter={() => sectionHover(section)}
       onMouseLeave={sectionHoverOff}
-      disabled={disabled || isUnscheduled}
+      disabled={disabled || sectionIsUnscheduled}
     >
       <ListItemText>
         <Typography variant="h6" className={classes.sectionTitle}>
@@ -34,7 +33,7 @@ function SectionResult({ addSection, sectionHover, sectionHoverOff, section, dis
 
         {section.schedule.map((scheduleObj, index) => (
           /* eslint-disable react/no-array-index-key */
-          <Typography color={isUnscheduled ? 'error' : undefined} key={index}>
+          <Typography color={sectionIsUnscheduled ? 'error' : undefined} key={index}>
             {getFormattedClassSchedule(scheduleObj)}
           </Typography>
           /* eslint-enable react/no-array-index-key */

--- a/src/components/Sidebar/common/SectionResult.test.js
+++ b/src/components/Sidebar/common/SectionResult.test.js
@@ -47,12 +47,15 @@ describe('SectionResult', () => {
 
   it('turns scheduled text to red if section is unscheduled', () => {
     timeUtils.getFormattedClassSchedule.mockReturnValue('TBA');
+    timeUtils.isUnscheduled.mockReturnValue(true);
     const unscheduledSection = {
       id: '3',
       sectionNumber: 21,
       schedule: [{
         location: 'Some other building',
         dow: 'TBA',
+        start: 'TBA',
+        end: 'TBA',
       }],
       instructors: ['Ian Horswill', 'Vincent St-Amour'],
     };

--- a/src/reducers/browse.js
+++ b/src/reducers/browse.js
@@ -1,5 +1,6 @@
 import { fromJS } from 'immutable';
 import { loop, Cmd } from 'redux-loop';
+import { isUnscheduled } from 'util/time';
 import {
   getSchoolsSuccess,
   getSchoolsFailure,
@@ -53,7 +54,12 @@ function handleChangeBrowseLevel(state, { browseLevel }) {
 }
 
 function handleAddSectionFromBrowse(state, { section }) {
-  if (section.associatedClasses) {
+  const canScheduleAnAssociatedClass = section.associatedClasses
+    && section.associatedClasses.some(
+      associatedClass => !isUnscheduled(associatedClass.schedule),
+    );
+
+  if (canScheduleAnAssociatedClass) {
     return state
       .set('currentBrowseLevel', 'associatedClass')
       .update('selected', selected => selected.set('section', fromJS(section)));

--- a/src/reducers/schedule.js
+++ b/src/reducers/schedule.js
@@ -1,5 +1,6 @@
 import { fromJS } from 'immutable';
 import { classColors, northwesternPurple30 } from 'util/colors';
+import { isUnscheduled } from 'util/time';
 import * as actionTypes from 'actions/action-types';
 import splitBySchedules from './add-section-handler-helpers/split-by-schedules';
 import prepClassesForCalendar from './add-section-handler-helpers/prep-classes-for-calendar';
@@ -28,8 +29,12 @@ function handleAddSection(state, { section }) {
   const color = getNextColor(state.get('colorUses'));
   const { sections } = prepClassesForCalendar(allSections, color);
 
-  // TODO: Figure out what to do if all associated classes are unscheduled
-  if (section.associatedClasses) {
+  const canScheduleAnAssociatedClass = section.associatedClasses
+    && section.associatedClasses.some(
+      associatedClass => !isUnscheduled(associatedClass.schedule),
+    );
+
+  if (canScheduleAnAssociatedClass) {
     const parsedNewSections = sections.filter(
       sectionWithCalendarInfo => sectionWithCalendarInfo.get('id') === section.id,
     );

--- a/src/reducers/search.js
+++ b/src/reducers/search.js
@@ -1,5 +1,6 @@
 import { fromJS } from 'immutable';
 import { loop, Cmd } from 'redux-loop';
+import { isUnscheduled } from 'util/time';
 import * as actionTypes from 'actions/action-types';
 import {
   getSearchResultsSuccess,
@@ -25,7 +26,12 @@ export const initialSearchState = fromJS({
 });
 
 function handleAddSection(state, { section }) {
-  if (section.associatedClasses) {
+  const canScheduleAnAssociatedClass = section.associatedClasses
+    && section.associatedClasses.some(
+      associatedClass => !isUnscheduled(associatedClass.schedule),
+    );
+
+  if (canScheduleAnAssociatedClass) {
     return state.merge({
       view: 'associatedClassesSelection',
       currentSectionNumber: section.sectionNumber,

--- a/src/reducers/search.test.js
+++ b/src/reducers/search.test.js
@@ -10,9 +10,12 @@ import {
   fetchSectionsForSearchSuccess,
   fetchSectionsForSearchFailure,
 } from 'actions';
+import * as timeUtils from 'util/time';
 import searchReducer, { initialSearchState } from './search';
 import * as actionTypes from '../actions/action-types';
 import * as actionCreators from '../actions/index';
+
+jest.mock('util/time');
 
 describe('search reducer', () => {
   it('should return initial state', () => {
@@ -176,13 +179,51 @@ describe('search reducer', () => {
   });
 
   it(`should handle ${actionTypes.ADD_SECTION_FROM_SEARCH} if there are associated classes`, () => {
-    const section = { associatedClasses: [], sectionNumber: '12' };
+    timeUtils.isUnscheduled.mockReturnValue(false);
+    const section = {
+      associatedClasses: [{
+        schedule: {
+          dow: [
+            'Fr',
+          ],
+          end: {
+            hour: 13,
+            minute: 50,
+          },
+          location: 'Annenberg Hall G01',
+          start: {
+            hour: 13,
+            minute: 0,
+          },
+        },
+        type: 'LAB',
+      }],
+      sectionNumber: '12',
+    };
     const action = actionCreators.addSectionFromSearch(section);
     expect(searchReducer(initialSearchState, action)).toEqual(initialSearchState.merge({
       view: 'associatedClassesSelection',
       currentSectionNumber: section.sectionNumber,
       currentAssociatedClasses: section.associatedClasses,
     }));
+  });
+
+  it(`should handle ${actionTypes.ADD_SECTION_FROM_SEARCH} if there are associated classes that are all unscheduled`, () => {
+    timeUtils.isUnscheduled.mockReturnValue(true);
+    const section = {
+      associatedClasses: [{
+        schedule: {
+          dow: 'TBA',
+          end: 'TBA',
+          location: 'Annenberg Hall G01',
+          start: 'TBA',
+        },
+        type: 'LAB',
+      }],
+      sectionNumber: '12',
+    };
+    const action = actionCreators.addSectionFromSearch(section);
+    expect(searchReducer(initialSearchState, action)).toEqual(initialSearchState);
   });
 
   it(`should handle ${actionTypes.ADD_SECTION_WITH_ASSOCIATED_CLASS_FROM_SEARCH}`, () => {

--- a/src/util/time.js
+++ b/src/util/time.js
@@ -48,3 +48,7 @@ export function overlaps(event1, event2) {
   }
   return !(isBefore(event1.end, event2.start) || isBefore(event2.end, event1.start));
 }
+
+export function isUnscheduled(event) {
+  return event.dow === 'TBA' || event.start === 'TBA' || event.end === 'TBA';
+}

--- a/src/util/time.test.js
+++ b/src/util/time.test.js
@@ -1,4 +1,4 @@
-import { getFormattedClassSchedule, formatMinute, formatTime, getDurationInHours, isBefore, overlaps, getFormattedEventTime } from './time';
+import { getFormattedClassSchedule, formatMinute, formatTime, getDurationInHours, isBefore, overlaps, getFormattedEventTime, isUnscheduled } from './time';
 
 describe('time utils', () => {
   describe('formatMinute', () => {
@@ -163,5 +163,27 @@ describe('time utils', () => {
 
   it('short circuits if the events\'s dows don\'t match', () => {
     expect(overlaps({ dow: 'Mo' }, { dow: 'Tu' })).toBe(false);
+  });
+
+  describe('isUnscheduled', () => {
+    it('determines if the event is unscheduled', () => {
+      expect(isUnscheduled({
+        dow: 'TBA',
+        start: 'TBA',
+        end: 'TBA',
+      })).toBe(true);
+
+      expect(isUnscheduled({
+        dow: 'Mo',
+        start: {
+          hour: 10,
+          minute: 30,
+        },
+        end: {
+          hour: 11,
+          minute: 0,
+        },
+      })).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
When a section is scheduled, but all of the associated classes associated with the section are unscheduled, there's no point in showing the associated classes selection since they won't be able to select any of them. Now, if you try to schedule a section where all the associated classes are unscheduled (use CSD 497 as an example), it will skip the associated class selection screen and directly schedule the course.

Also included in this PR is the movement of `isUnscheduled` into `util/time` as it is now used across four different files as opposed to just one previously. 