### PR TITLE
404 Page

### DIFF
--- a/__mocks__/@material-ui/styles.js
+++ b/__mocks__/@material-ui/styles.js
@@ -1,5 +1,0 @@
-// Grab the original exports
-const styles = jest.requireActual('@material-ui/styles');
-const makeStyles = () => ({});
-
-module.exports = { ...styles, makeStyles };

--- a/__mocks__/@material-ui/styles.js
+++ b/__mocks__/@material-ui/styles.js
@@ -1,0 +1,5 @@
+// Grab the original exports
+const styles = jest.requireActual('@material-ui/styles');
+const makeStyles = () => ({});
+
+module.exports = { ...styles, makeStyles };

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -17,6 +17,7 @@ import FAQPage from './pages/FAQPage';
 import BugReportPage from './pages/BugReportPage';
 import ContactPage from './pages/ContactPage';
 import LegalPage from './pages/LegalPage';
+import NotFoundPage from './pages/NotFoundPage';
 
 class App extends Component {
   constructor(props) {
@@ -65,6 +66,7 @@ class App extends Component {
         <Route path="/bugs" render={/* istanbul ignore next */ () => <BugReportPage />} />
         <Route path="/contact" render={/* istanbul ignore next */ () => <ContactPage />} />
         <Route path="/legal" render={/* istanbul ignore next */ () => <LegalPage />} />
+        <Route render={/* istanbul ignore next */ () => <NotFoundPage />} />
       </Fragment>
     );
   }

--- a/src/components/__snapshots__/App.test.js.snap
+++ b/src/components/__snapshots__/App.test.js.snap
@@ -34,6 +34,9 @@ exports[`App should render correctly 1`] = `
     path="/legal"
     render={[Function]}
   />
+  <Route
+    render={[Function]}
+  />
 </React.Fragment>
 `;
 
@@ -69,6 +72,9 @@ exports[`App should toggle navigation 1`] = `
   />
   <Route
     path="/legal"
+    render={[Function]}
+  />
+  <Route
     render={[Function]}
   />
 </React.Fragment>

--- a/src/components/pages/NotFoundPage.js
+++ b/src/components/pages/NotFoundPage.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+import { pageContainer, pageBody } from './common/styles';
+import PageTitle from './common/PageTitle';
+
+export const useStyles = makeStyles({
+  pageContainer,
+  pageBody,
+});
+
+export default function NotFoundPage() {
+  const classes = useStyles();
+  return (
+    <div className={classes.pageContainer}>
+      <PageTitle title="404 Page Not Found" />
+
+      <div className={classes.pageBody}>
+        <Typography variant="h5">
+          The requested URL was not found on this server.
+        </Typography>
+      </div>
+    </div>
+  );
+}

--- a/src/components/pages/NotFoundPage.test.js
+++ b/src/components/pages/NotFoundPage.test.js
@@ -1,12 +1,17 @@
-// import { wrapperCreator } from 'util/testing';
-// import { NotFoundPage, useStyles } from './NotFoundPage';
+import React from 'react';
+import { shallow } from 'enzyme';
+import { makeStyles } from '@material-ui/styles';
+import NotFoundPage from './NotFoundPage';
 
-// describe('FAQPage', () => {
-//   const getWrapper = wrapperCreator(NotFoundPage, undefined, useStyles);
+jest.mock('@material-ui/styles');
+jest.mock(makeStyles);
 
-//   it('should render correctly', () => {
-//     const wrapper = getWrapper();
+describe('FAQPage', () => {
+  it('should render correctly', () => {
+    const wrapper = shallow(
+      <NotFoundPage />,
+    );
 
-//     expect(wrapper.get(0)).toMatchSnapshot();
-//   });
-// });
+    expect(wrapper.get(0)).toMatchSnapshot();
+  });
+});

--- a/src/components/pages/NotFoundPage.test.js
+++ b/src/components/pages/NotFoundPage.test.js
@@ -1,10 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { makeStyles } from '@material-ui/styles';
 import NotFoundPage from './NotFoundPage';
-
-jest.mock('@material-ui/styles');
-jest.mock(makeStyles);
 
 describe('FAQPage', () => {
   it('should render correctly', () => {

--- a/src/components/pages/NotFoundPage.test.js
+++ b/src/components/pages/NotFoundPage.test.js
@@ -1,0 +1,12 @@
+// import { wrapperCreator } from 'util/testing';
+// import { NotFoundPage, useStyles } from './NotFoundPage';
+
+// describe('FAQPage', () => {
+//   const getWrapper = wrapperCreator(NotFoundPage, undefined, useStyles);
+
+//   it('should render correctly', () => {
+//     const wrapper = getWrapper();
+
+//     expect(wrapper.get(0)).toMatchSnapshot();
+//   });
+// });

--- a/src/components/pages/__snapshots__/NotFoundPage.test.js.snap
+++ b/src/components/pages/__snapshots__/NotFoundPage.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FAQPage should render correctly 1`] = `
+<div
+  className="makeStyles-pageContainer-1"
+>
+  <ForwardRef(WithStyles)
+    title="404 Page Not Found"
+  />
+  <div
+    className="makeStyles-pageBody-2"
+  >
+    <ForwardRef(WithStyles)
+      variant="h5"
+    >
+      The requested URL was not found on this server.
+    </ForwardRef(WithStyles)>
+  </div>
+</div>
+`;


### PR DESCRIPTION
This ticket implements a basic 404 redirect if the user tries to access any routes that have not been previously defined. This will also be the first component to use the `makeStyles` hook introduced in Material-UI v4. 