### PR TITLE
Remove 404 page not found shown at bottom

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { withRouter, Route } from 'react-router-dom';
+import { withRouter, Route, Switch } from 'react-router-dom';
 import {
   fetchCurrentTermRequest,
 } from 'actions';
@@ -53,17 +53,19 @@ class App extends Component {
       <Fragment>
         <TopBar menuAction={this.toggleNav} />
         <NavDrawer isOpen={navigationOpen} closeFunc={this.toggleNav} />
-        <Route
-          exact
-          path="/"
-          render={/* istanbul ignore next */ props => <AppBody {...props} />}
-        />
-        <Route path="/about" render={/* istanbul ignore next */() => <AboutPage />} />
-        <Route path="/faq" render={/* istanbul ignore next */ () => <FAQPage />} />
-        <Route path="/bugs" render={/* istanbul ignore next */ () => <BugReportPage />} />
-        <Route path="/contact" render={/* istanbul ignore next */ () => <ContactPage />} />
-        <Route path="/legal" render={/* istanbul ignore next */ () => <LegalPage />} />
-        <Route render={/* istanbul ignore next */ () => <NotFoundPage />} />
+        <Switch>
+          <Route
+            exact
+            path="/"
+            render={/* istanbul ignore next */ props => <AppBody {...props} />}
+          />
+          <Route path="/about" render={/* istanbul ignore next */() => <AboutPage />} />
+          <Route path="/faq" render={/* istanbul ignore next */ () => <FAQPage />} />
+          <Route path="/bugs" render={/* istanbul ignore next */ () => <BugReportPage />} />
+          <Route path="/contact" render={/* istanbul ignore next */ () => <ContactPage />} />
+          <Route path="/legal" render={/* istanbul ignore next */ () => <LegalPage />} />
+          <Route render={/* istanbul ignore next */ () => <NotFoundPage />} />
+        </Switch>
       </Fragment>
     );
   }

--- a/src/components/__snapshots__/App.test.js.snap
+++ b/src/components/__snapshots__/App.test.js.snap
@@ -9,34 +9,36 @@ exports[`App should render correctly 1`] = `
     closeFunc={[Function]}
     isOpen={false}
   />
-  <Route
-    exact={true}
-    path="/"
-    render={[Function]}
-  />
-  <Route
-    path="/about"
-    render={[Function]}
-  />
-  <Route
-    path="/faq"
-    render={[Function]}
-  />
-  <Route
-    path="/bugs"
-    render={[Function]}
-  />
-  <Route
-    path="/contact"
-    render={[Function]}
-  />
-  <Route
-    path="/legal"
-    render={[Function]}
-  />
-  <Route
-    render={[Function]}
-  />
+  <Switch>
+    <Route
+      exact={true}
+      path="/"
+      render={[Function]}
+    />
+    <Route
+      path="/about"
+      render={[Function]}
+    />
+    <Route
+      path="/faq"
+      render={[Function]}
+    />
+    <Route
+      path="/bugs"
+      render={[Function]}
+    />
+    <Route
+      path="/contact"
+      render={[Function]}
+    />
+    <Route
+      path="/legal"
+      render={[Function]}
+    />
+    <Route
+      render={[Function]}
+    />
+  </Switch>
 </React.Fragment>
 `;
 
@@ -49,33 +51,35 @@ exports[`App should toggle navigation 1`] = `
     closeFunc={[Function]}
     isOpen={true}
   />
-  <Route
-    exact={true}
-    path="/"
-    render={[Function]}
-  />
-  <Route
-    path="/about"
-    render={[Function]}
-  />
-  <Route
-    path="/faq"
-    render={[Function]}
-  />
-  <Route
-    path="/bugs"
-    render={[Function]}
-  />
-  <Route
-    path="/contact"
-    render={[Function]}
-  />
-  <Route
-    path="/legal"
-    render={[Function]}
-  />
-  <Route
-    render={[Function]}
-  />
+  <Switch>
+    <Route
+      exact={true}
+      path="/"
+      render={[Function]}
+    />
+    <Route
+      path="/about"
+      render={[Function]}
+    />
+    <Route
+      path="/faq"
+      render={[Function]}
+    />
+    <Route
+      path="/bugs"
+      render={[Function]}
+    />
+    <Route
+      path="/contact"
+      render={[Function]}
+    />
+    <Route
+      path="/legal"
+      render={[Function]}
+    />
+    <Route
+      render={[Function]}
+    />
+  </Switch>
 </React.Fragment>
 `;


### PR DESCRIPTION
After the 404 Page Not Found routing was implemented, a bug was introduced where at the bottom of every route, the 404 component was rendering. 

This was because we weren't using `Switch` provided by `react-router-dom` - what `Switch` does is that it makes sure that the only route rendered is the first match. Without `Switch`, subsequent potential matches will also be rendered, and the nature of the 404 route makes it so that it would always match since it is a catch-all match.