### PR TITLE
Convert to makeStyle hooks

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -98,18 +98,16 @@ When writing new test files, we recommend writing tests for leaf components firs
 
 We use snapshot testing. This can be dangerous if a developer blindly updates the snapshots after any and every change. The design and functionality of the component should always be manually tested and confirmed before handling any of the snapshots. The existing snapshots should always be manually compared with the changes made to confirm that the differences are as expected before updating the snapshot. This way, we gain the speed benefits of snapshot testing as well as the bug-catching benefits.
 
-When testing styled components, export an unstyled version of the component (the component not wrapped with the `withStyles` higher order component) and test this unstyled component. This prevents the snapshots from snapshotting the higher order component. Export the styles from the component as well, and use it with the `mockStyles` util function to provide the component with the `classes` prop that it is expecting.
+When testing styled components, we use shallow rendering with Enzyme. 
 
 ```javascript
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles } from 'util/testing';
-import { UnstyledSearchBox, styles } from './SearchBox';
+import SearchBox from './SearchBox';
 
 describe('SearchBox', () => {
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledSearchBox classes={classes} />);
+    const wrapper = shallow(<SearchBox />);
     // The rest of the test...
   });
 

--- a/src/components/AppBody.js
+++ b/src/components/AppBody.js
@@ -1,17 +1,17 @@
 import React from 'react';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import Grid from '@material-ui/core/Grid';
-import PropTypes from 'prop-types';
 import CalendarView from './calendar/CalendarView';
 import SidebarView from './sidebar/SidebarView';
 
-export const styles = {
+const useStyles = makeStyles({
   calendar: {
     overflow: 'auto',
   },
-};
+});
 
-function AppBody({ classes }) {
+export default function AppBody() {
+  const classes = useStyles();
   return (
     <Grid container>
       <Grid item md={9} sm={12} xs={12} className={classes.calendar}>
@@ -24,10 +24,3 @@ function AppBody({ classes }) {
     </Grid>
   );
 }
-
-AppBody.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { AppBody as UnstyledAppBody };
-export default withStyles(styles)(AppBody);

--- a/src/components/AppBody.test.js
+++ b/src/components/AppBody.test.js
@@ -1,13 +1,12 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledAppBody, styles } from './AppBody';
+import React from 'react';
+import { shallow } from 'enzyme';
+import AppBody from './AppBody';
 
 jest.mock('images/hero-image.jpg');
 
 describe('AppBody', () => {
-  const getWrapper = wrapperCreator(UnstyledAppBody, undefined, styles);
-
   it('should render correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<AppBody />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/NavDrawer.js
+++ b/src/components/NavDrawer.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Drawer, List, ListItem, ListItemText, Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 
-export const styles = {
+const useStyles = makeStyles({
   drawer: {
     display: 'flex',
     flexDirection: 'column',
@@ -14,14 +14,15 @@ export const styles = {
   legalLink: {
     margin: '5px auto',
   },
-};
+});
 
 /* istanbul ignore next */
 function ListItemLink(props) {
   return <ListItem button component={Link} {...props} />;
 }
 
-function NavDrawer({ isOpen, closeFunc, classes }) {
+export default function NavDrawer({ isOpen, closeFunc }) {
+  const classes = useStyles();
   return (
     <Drawer onClose={closeFunc} open={isOpen}>
       <div className={classes.drawer}>
@@ -58,8 +59,4 @@ function NavDrawer({ isOpen, closeFunc, classes }) {
 NavDrawer.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   closeFunc: PropTypes.func.isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
-
-export { NavDrawer as UnstyledNavDrawer };
-export default withStyles(styles)(NavDrawer);

--- a/src/components/NavDrawer.test.js
+++ b/src/components/NavDrawer.test.js
@@ -1,14 +1,15 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledNavDrawer, styles } from './NavDrawer';
+import React from 'react';
+import { shallow } from 'enzyme';
+import NavDrawer from './NavDrawer';
 
 describe('NavDrawer', () => {
   const defaultProps = {
     isOpen: true,
     closeFunc: () => {},
   };
-  const getWrapper = wrapperCreator(UnstyledNavDrawer, defaultProps, styles);
+
   it('should render correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<NavDrawer {...defaultProps} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/TopBar.js
+++ b/src/components/TopBar.js
@@ -5,11 +5,11 @@ import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import Typography from '@material-ui/core/Typography';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 
 const topBarTextColor = 'white';
 
-export const styles = {
+const useStyles = makeStyles({
   title: {
     color: topBarTextColor,
   },
@@ -25,9 +25,10 @@ export const styles = {
     display: 'flex',
     alignItems: 'center',
   },
-};
+});
 
-function TopBar({ classes, menuAction }) {
+export default function TopBar({ menuAction }) {
+  const classes = useStyles();
   return (
     <AppBar position="static">
       <Toolbar className={classes.toolbar}>
@@ -45,10 +46,5 @@ function TopBar({ classes, menuAction }) {
 }
 
 TopBar.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
   menuAction: PropTypes.func.isRequired,
 };
-
-export { TopBar as UnstyledTopBar };
-
-export default withStyles(styles)(TopBar);

--- a/src/components/TopBar.test.js
+++ b/src/components/TopBar.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles } from 'util/testing';
-import { UnstyledTopBar, styles } from './TopBar';
+import TopBar from './TopBar';
 
 describe('TopBar', () => {
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledTopBar classes={classes} menuAction={() => {}} />);
+    const wrapper = shallow(<TopBar menuAction={() => {}} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/__snapshots__/App.test.js.snap
+++ b/src/components/__snapshots__/App.test.js.snap
@@ -2,115 +2,37 @@
 
 exports[`App should render correctly 1`] = `
 <React.Fragment>
-  <ForwardRef(WithStyles)
+  <TopBar
     menuAction={[Function]}
   />
-  <ForwardRef(WithStyles)
+  <NavDrawer
     closeFunc={[Function]}
     isOpen={false}
   />
   <Switch>
     <Route
-      component={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "Naked": [Function],
-          "displayName": "WithStyles(AppBody)",
-          "options": Object {},
-          "propTypes": Object {
-            "classes": [Function],
-            "innerRef": [Function],
-          },
-          "render": [Function],
-          "useStyles": [Function],
-        }
-      }
+      component={[Function]}
       exact={true}
       path="/"
     />
     <Route
-      component={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "Naked": [Function],
-          "displayName": "WithStyles(AboutPage)",
-          "options": Object {},
-          "propTypes": Object {
-            "classes": [Function],
-            "innerRef": [Function],
-          },
-          "render": [Function],
-          "useStyles": [Function],
-        }
-      }
+      component={[Function]}
       path="/about"
     />
     <Route
-      component={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "Naked": [Function],
-          "displayName": "WithStyles(FAQPage)",
-          "options": Object {},
-          "propTypes": Object {
-            "classes": [Function],
-            "innerRef": [Function],
-          },
-          "render": [Function],
-          "useStyles": [Function],
-        }
-      }
+      component={[Function]}
       path="/faq"
     />
     <Route
-      component={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "Naked": [Function],
-          "displayName": "WithStyles(BugReportPage)",
-          "options": Object {},
-          "propTypes": Object {
-            "classes": [Function],
-            "innerRef": [Function],
-          },
-          "render": [Function],
-          "useStyles": [Function],
-        }
-      }
+      component={[Function]}
       path="/bugs"
     />
     <Route
-      component={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "Naked": [Function],
-          "displayName": "WithStyles(ContactPage)",
-          "options": Object {},
-          "propTypes": Object {
-            "classes": [Function],
-            "innerRef": [Function],
-          },
-          "render": [Function],
-          "useStyles": [Function],
-        }
-      }
+      component={[Function]}
       path="/contact"
     />
     <Route
-      component={
-        Object {
-          "$$typeof": Symbol(react.forward_ref),
-          "Naked": [Function],
-          "displayName": "WithStyles(LegalPage)",
-          "options": Object {},
-          "propTypes": Object {
-            "classes": [Function],
-            "innerRef": [Function],
-          },
-          "render": [Function],
-          "useStyles": [Function],
-        }
-      }
+      component={[Function]}
       path="/legal"
     />
     <Route

--- a/src/components/__snapshots__/AppBody.test.js.snap
+++ b/src/components/__snapshots__/AppBody.test.js.snap
@@ -5,13 +5,13 @@ exports[`AppBody should render correctly 1`] = `
   container={true}
 >
   <ForwardRef(WithStyles)
-    className=""
+    className="makeStyles-calendar-1"
     item={true}
     md={9}
     sm={12}
     xs={12}
   >
-    <ForwardRef(WithStyles) />
+    <CalendarView />
   </ForwardRef(WithStyles)>
   <ForwardRef(WithStyles)
     item={true}
@@ -19,7 +19,7 @@ exports[`AppBody should render correctly 1`] = `
     sm={12}
     xs={12}
   >
-    <ForwardRef(WithStyles) />
+    <SidebarView />
   </ForwardRef(WithStyles)>
 </ForwardRef(WithStyles)>
 `;

--- a/src/components/__snapshots__/NavDrawer.test.js.snap
+++ b/src/components/__snapshots__/NavDrawer.test.js.snap
@@ -6,7 +6,7 @@ exports[`NavDrawer should render correctly 1`] = `
   open={true}
 >
   <div
-    className=""
+    className="makeStyles-drawer-1"
   >
     <ForwardRef(WithStyles)>
       <ListItemLink
@@ -51,7 +51,7 @@ exports[`NavDrawer should render correctly 1`] = `
       </ListItemLink>
     </ForwardRef(WithStyles)>
     <div
-      className=""
+      className="makeStyles-legalLink-2"
     >
       <Link
         onClick={[Function]}

--- a/src/components/__snapshots__/TopBar.test.js.snap
+++ b/src/components/__snapshots__/TopBar.test.js.snap
@@ -5,28 +5,28 @@ exports[`TopBar renders correctly 1`] = `
   position="static"
 >
   <ForwardRef(WithStyles)
-    className=""
+    className="makeStyles-toolbar-3"
   >
     <div
-      className=""
+      className="makeStyles-topBarLeftSection-4"
     >
       <ForwardRef(WithStyles)
         aria-label="Navigation"
         onClick={[Function]}
       >
         <pure(Menu)
-          className=""
+          className="makeStyles-icon-2"
         />
       </ForwardRef(WithStyles)>
       <ForwardRef(WithStyles)
-        className=""
+        className="makeStyles-title-1"
         variant="h5"
       >
         Serif.nu
       </ForwardRef(WithStyles)>
     </div>
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-title-1"
     >
       Term: Fall 2019
     </ForwardRef(WithStyles)>

--- a/src/components/calendar/AssociatedClass.js
+++ b/src/components/calendar/AssociatedClass.js
@@ -1,6 +1,6 @@
-import React, { Component, Fragment } from 'react';
+import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { getFormattedEventTime, getDurationInHours } from 'util/time';
 import Section from 'components/common/Section';
 import ClassModal from './ClassModal';
@@ -40,52 +40,45 @@ export const styles = {
   },
 };
 
-class AssociatedClass extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showDialog: false,
-    };
-    this.toggleDialog = this.toggleDialog.bind(this);
+const useStyles = makeStyles(styles);
+
+export default function AssociatedClass({ associatedClass, section, isPreview }) {
+  const classes = useStyles({ associatedClass, isPreview });
+  const [showDialog, setShowDialog] = useState(false);
+
+  function toggleDialog() {
+    setShowDialog(!showDialog);
   }
 
-  toggleDialog() {
-    this.setState(state => ({ showDialog: !state.showDialog }));
-  }
+  const leftHeaderContent = getFormattedEventTime(associatedClass.event);
+  const rightHeaderContent = `${section.subjectId} ${section.courseId}`;
+  const associatedClassTitle = `${associatedClass.type} - ${section.name}`;
 
-  render() {
-    const { classes, associatedClass, section } = this.props;
-    const { showDialog } = this.state;
-
-    const leftHeaderContent = getFormattedEventTime(associatedClass.event);
-    const rightHeaderContent = `${section.subjectId} ${section.courseId}`;
-    const associatedClassTitle = `${associatedClass.type} - ${section.name}`;
-
-    return (
-      <Fragment>
-        <Section
-          onClick={this.toggleDialog}
-          classes={classes}
-          leftHeaderContent={leftHeaderContent}
-          rightHeaderContent={rightHeaderContent}
-          sectionName={associatedClassTitle}
-        />
-        <ClassModal
-          section={section}
-          associatedClass={associatedClass}
-          showDialog={showDialog}
-          toggleDialog={this.toggleDialog}
-        />
-      </Fragment>
-    );
-  }
+  return (
+    <Fragment>
+      <Section
+        onClick={toggleDialog}
+        classes={classes}
+        leftHeaderContent={leftHeaderContent}
+        rightHeaderContent={rightHeaderContent}
+        sectionName={associatedClassTitle}
+      />
+      <ClassModal
+        section={section}
+        associatedClass={associatedClass}
+        showDialog={showDialog}
+        toggleDialog={toggleDialog}
+      />
+    </Fragment>
+  );
 }
 
 AssociatedClass.propTypes = {
   associatedClass: PropTypes.objectOf(PropTypes.any).isRequired, // TODO
   section: PropTypes.objectOf(PropTypes.any).isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
+  isPreview: PropTypes.bool,
 };
 
-export { AssociatedClass as UnstyledAssociatedClass };
-export default withStyles(styles)(AssociatedClass);
+AssociatedClass.defaultProps = {
+  isPreview: false,
+};

--- a/src/components/calendar/AssociatedClass.test.js
+++ b/src/components/calendar/AssociatedClass.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { wrapperCreator, mockStyles } from 'util/testing';
 import * as timeUtils from 'util/time';
 import Section from 'components/common/Section';
 import ClassModal from './ClassModal';
-import { UnstyledAssociatedClass, styles, MAX_WIDTH_PERCENT } from './AssociatedClass';
+import AssociatedClass, { styles, MAX_WIDTH_PERCENT } from './AssociatedClass';
 
 jest.mock('util/time');
 
@@ -56,23 +55,39 @@ describe('dynamic styles', () => {
 });
 
 describe('AssociatedClass', () => {
-  const defaultProps = {
-    associatedClass: { type: 'DIS', name: 'Some discussion' },
-    section: { subjectId: 'EECS', courseId: '111-0' },
+  const dow = 'Mo';
+  const event = {
+    dow,
+    start: {
+      hour: 10,
+      minute: 30,
+    },
+    end: {
+      hour: 12,
+      minute: 0,
+    },
   };
-  const getWrapper = wrapperCreator(UnstyledAssociatedClass, defaultProps, styles);
+  const color = 'some color';
+  const associatedClass = { event, color, column: 0, columnWidth: 1 };
+
+  const defaultProps = {
+    associatedClass,
+    section: { subjectId: 'EECS', courseId: '111-0' },
+    isPreview: false,
+  };
 
   it('renders correctly', () => {
     timeUtils.getFormattedEventTime.mockReturnValue('left hand header content');
-    const wrapper = getWrapper();
+    const wrapper = shallow(
+      <AssociatedClass {...defaultProps} />,
+    );
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('renders modal correctly', () => {
-    const classes = mockStyles(styles);
     const wrapper = shallow(
-      <UnstyledAssociatedClass {...defaultProps} classes={classes} />,
+      <AssociatedClass {...defaultProps} />,
     );
 
     wrapper.find(Section).simulate('click');

--- a/src/components/calendar/CalendarSection.js
+++ b/src/components/calendar/CalendarSection.js
@@ -1,6 +1,6 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { getFormattedEventTime, getDurationInHours } from 'util/time';
 import Section from 'components/common/Section';
 import ClassModal from './ClassModal';
@@ -40,62 +40,49 @@ export const styles = {
   },
 };
 
-class CalendarSection extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showDialog: false,
-    };
-    this.handleClick = this.handleClick.bind(this);
-    this.toggleDialog = this.toggleDialog.bind(this);
+const useStyles = makeStyles(styles);
+
+export default function CalendarSection({ section, isPreview }) {
+  const [showDialog, setShowDialog] = useState(false);
+
+  const classes = useStyles({ section, isPreview });
+
+  function toggleDialog() {
+    setShowDialog(!showDialog);
   }
 
-  handleClick() {
-    const { isPreview } = this.props;
+  const handleClick = () => {
     if (!isPreview) {
-      this.toggleDialog();
+      toggleDialog();
     }
-  }
+  };
 
-  toggleDialog() {
-    this.setState(state => ({ showDialog: !state.showDialog }));
-  }
+  const leftHeaderContent = getFormattedEventTime(section.event);
+  const rightHeaderContent = `${section.subjectId} ${section.courseId}`;
 
-  render() {
-    const { classes, section } = this.props;
-    const { showDialog } = this.state;
-
-    const leftHeaderContent = getFormattedEventTime(section.event);
-    const rightHeaderContent = `${section.subjectId} ${section.courseId}`;
-
-    return (
-      <div>
-        <Section
-          onClick={this.handleClick}
-          classes={classes}
-          leftHeaderContent={leftHeaderContent}
-          rightHeaderContent={rightHeaderContent}
-          sectionName={section.name}
-        />
-        <ClassModal
-          section={section}
-          showDialog={showDialog}
-          toggleDialog={this.toggleDialog}
-        />
-      </div>
-    );
-  }
+  return (
+    <div>
+      <Section
+        onClick={handleClick}
+        classes={classes}
+        leftHeaderContent={leftHeaderContent}
+        rightHeaderContent={rightHeaderContent}
+        sectionName={section.name}
+      />
+      <ClassModal
+        section={section}
+        showDialog={showDialog}
+        toggleDialog={toggleDialog}
+      />
+    </div>
+  );
 }
 
 CalendarSection.propTypes = {
   section: PropTypes.objectOf(PropTypes.any).isRequired, // TODO
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
   isPreview: PropTypes.bool,
 };
 
 CalendarSection.defaultProps = {
   isPreview: false,
 };
-
-export { CalendarSection as UnstyledCalendarSection };
-export default withStyles(styles)(CalendarSection);

--- a/src/components/calendar/CalendarSection.test.js
+++ b/src/components/calendar/CalendarSection.test.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles } from 'util/testing';
 import Section from 'components/common/Section';
 import ClassModal from './ClassModal';
-import { UnstyledCalendarSection, styles, MAX_WIDTH_PERCENT } from './CalendarSection';
+import CalendarSection, { styles, MAX_WIDTH_PERCENT } from './CalendarSection';
 
 describe('CalendarSection', () => {
   const dow = 'Mo';
@@ -18,6 +17,8 @@ describe('CalendarSection', () => {
       minute: 0,
     },
   };
+
+  const testSection = { id: '12345', course: '101-1', event };
 
   describe('dynamic styles', () => {
     const hour = 10;
@@ -62,20 +63,16 @@ describe('CalendarSection', () => {
   });
 
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const testSection = { id: '12345', course: '101-1', event };
     const wrapper = shallow(
-      <UnstyledCalendarSection section={testSection} classes={classes} />,
+      <CalendarSection section={testSection} />,
     );
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('renders modal correctly', () => {
-    const classes = mockStyles(styles);
-    const testSection = { id: '12345', course: '101-1', event };
     const wrapper = shallow(
-      <UnstyledCalendarSection section={testSection} classes={classes} />,
+      <CalendarSection section={testSection} />,
     );
 
     wrapper.find(Section).simulate('click');
@@ -84,10 +81,8 @@ describe('CalendarSection', () => {
   });
 
   it('does nothing as a preview section when clicked', () => {
-    const classes = mockStyles(styles);
-    const testSection = { id: '12345', course: '101-1', event };
     const wrapper = shallow(
-      <UnstyledCalendarSection section={testSection} classes={classes} isPreview />,
+      <CalendarSection section={testSection} isPreview />,
     );
 
     wrapper.find(Section).simulate('click');

--- a/src/components/calendar/CalendarView.js
+++ b/src/components/calendar/CalendarView.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { HOURS, DOWS } from './calendar-constants';
 import HoursColumn from './HoursColumn';
 import DowColumn from './DowColumn';
 
-export const styles = {
+const useStyles = makeStyles({
   calendarRoot: {
     height: 'calc(100vh - 64px)',
     // 64px is height of TopBar
@@ -15,9 +14,10 @@ export const styles = {
     display: 'flex',
     width: '100%',
   },
-};
+});
 
-function CalendarView({ classes }) {
+export default function CalendarView() {
+  const classes = useStyles();
   return (
     <div className={classes.calendarRoot}>
       <HoursColumn hours={HOURS} />
@@ -30,11 +30,3 @@ function CalendarView({ classes }) {
     </div>
   );
 }
-
-CalendarView.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { CalendarView as UnstyledCalendarView };
-
-export default withStyles(styles)(CalendarView);

--- a/src/components/calendar/CalendarView.test.js
+++ b/src/components/calendar/CalendarView.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles } from 'util/testing';
-import { UnstyledCalendarView, styles } from './CalendarView';
+import CalendarView from './CalendarView';
 
 describe('CalendarView', () => {
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledCalendarView classes={classes} />);
+    const wrapper = shallow(<CalendarView />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/calendar/DowColumn.js
+++ b/src/components/calendar/DowColumn.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import Typography from '@material-ui/core/Typography';
 import {
   HOURS,
@@ -10,7 +10,7 @@ import {
 } from './calendar-constants';
 import HourCell from './HourCell';
 
-export const styles = {
+const useStyles = makeStyles({
   dowColumn: {
     flexGrow: 1,
     borderRight: columnBorderStyle,
@@ -24,7 +24,7 @@ export const styles = {
     display: 'flex',
     flexDirection: 'column',
   },
-};
+});
 
 /* istanbul ignore next */
 function getDisplayDow(dow) {
@@ -44,7 +44,8 @@ function getDisplayDow(dow) {
   }
 }
 
-function DowColumn({ dow, classes }) {
+export default function DowColumn({ dow }) {
+  const classes = useStyles();
   return (
     <div className={classes.dowColumn}>
       <Typography className={classes.dowHeader} align="center" variant="body1">
@@ -62,9 +63,4 @@ function DowColumn({ dow, classes }) {
 
 DowColumn.propTypes = {
   dow: PropTypes.string.isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
-
-export { DowColumn as UnstyledDowColumn };
-
-export default withStyles(styles)(DowColumn);

--- a/src/components/calendar/DowColumn.test.js
+++ b/src/components/calendar/DowColumn.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles } from 'util/testing';
-import { UnstyledDowColumn, styles } from './DowColumn';
+import DowColumn from './DowColumn';
 
 describe('DowColumn', () => {
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledDowColumn dow="Mon" classes={classes} />);
+    const wrapper = shallow(<DowColumn dow="Mon" />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/calendar/HourCell.js
+++ b/src/components/calendar/HourCell.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import {
   sectionsSelector,
   sectionsForHourSelector,
@@ -14,16 +14,18 @@ import { columnBorderStyle, cellMinHeight } from './calendar-constants';
 import CalendarSection from './CalendarSection';
 import AssociatedClass from './AssociatedClass';
 
-export const styles = {
+const useStyles = makeStyles({
   calendarCell: {
     flexGrow: 1,
     borderBottom: columnBorderStyle,
     minHeight: cellMinHeight,
     position: 'relative',
   },
-};
+});
 
-function HourCell({ hour, dow, classes }) {
+export default function HourCell({ hour, dow }) {
+  const classes = useStyles();
+
   const sections = useSelector(state => sectionsForHourSelector(state, hour, dow));
   const associatedClasses = useSelector(
     state => associatedClassesForHourSelector(state, hour, dow),
@@ -62,9 +64,4 @@ function HourCell({ hour, dow, classes }) {
 HourCell.propTypes = {
   hour: PropTypes.number.isRequired,
   dow: PropTypes.string.isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
-
-export { HourCell as UnstyledHourCell };
-
-export default withStyles(styles)(HourCell);

--- a/src/components/calendar/HourCell.test.js
+++ b/src/components/calendar/HourCell.test.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles, mockUseSelector } from 'util/testing';
+import { mockUseSelector } from 'util/testing';
 import * as selectors from 'selectors';
-import { UnstyledHourCell, styles } from './HourCell';
+import HourCell from './HourCell';
 import CalendarSection from './CalendarSection';
 import AssociatedClass from './AssociatedClass';
 
@@ -12,7 +12,7 @@ describe('HourCell', () => {
   const testSections = [{ id: '12345' }];
   const allSections = [{ id: '12345' }];
   const allSectionPreviews = [];
-  const associatedClasses = [{ event: {} }];
+  const associatedClasses = [{ sectionId: '12345', event: {} }];
 
   let useSelectorMock;
 
@@ -23,12 +23,10 @@ describe('HourCell', () => {
   });
 
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
     const wrapper = shallow(
-      <UnstyledHourCell
+      <HourCell
         hour={10}
         dow="Mo"
-        classes={classes}
       />,
     );
 
@@ -36,12 +34,10 @@ describe('HourCell', () => {
   });
 
   it('calls sectionsForHourSelector correctly', () => {
-    const classes = mockStyles(styles);
     shallow(
-      <UnstyledHourCell
+      <HourCell
         hour={10}
         dow="Mo"
-        classes={classes}
       />,
     );
 
@@ -51,12 +47,10 @@ describe('HourCell', () => {
   });
 
   it('calls associatedClassesForHourSelector correctly', () => {
-    const classes = mockStyles(styles);
     shallow(
-      <UnstyledHourCell
+      <HourCell
         hour={10}
         dow="Mo"
-        classes={classes}
       />,
     );
 
@@ -66,12 +60,10 @@ describe('HourCell', () => {
   });
 
   it('calls sectionPreviewSelector correctly', () => {
-    const classes = mockStyles(styles);
     shallow(
-      <UnstyledHourCell
+      <HourCell
         hour={10}
         dow="Mo"
-        classes={classes}
       />,
     );
 
@@ -81,12 +73,10 @@ describe('HourCell', () => {
   });
 
   it('calls associatedClassPreviewSelector correctly', () => {
-    const classes = mockStyles(styles);
     shallow(
-      <UnstyledHourCell
+      <HourCell
         hour={10}
         dow="Mo"
-        classes={classes}
       />,
     );
 
@@ -96,7 +86,6 @@ describe('HourCell', () => {
   });
 
   it('renders section previews', () => {
-    const classes = mockStyles(styles);
     const sectionPreview = { id: '12345' };
 
     mockUseSelector(
@@ -104,10 +93,9 @@ describe('HourCell', () => {
     );
 
     const wrapper = shallow(
-      <UnstyledHourCell
+      <HourCell
         hour={10}
         dow="Mo"
-        classes={classes}
       />,
     );
 
@@ -115,7 +103,6 @@ describe('HourCell', () => {
   });
 
   it('renders associated class previews', () => {
-    const classes = mockStyles(styles);
     const associatedClassPreview = { type: 'LAB' };
 
     mockUseSelector(
@@ -123,10 +110,9 @@ describe('HourCell', () => {
     );
 
     const wrapper = shallow(
-      <UnstyledHourCell
+      <HourCell
         hour={10}
         dow="Mo"
-        classes={classes}
       />,
     );
 

--- a/src/components/calendar/HoursColumn.js
+++ b/src/components/calendar/HoursColumn.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { Typography } from '@material-ui/core';
 import {
   columnBorderStyle,
@@ -10,7 +10,7 @@ import {
   columnHeight,
 } from './calendar-constants';
 
-export const styles = {
+const useStyles = makeStyles({
   hoursColumnContainer: {
     minHeight: columnMinHeight,
     borderRight: columnBorderStyle,
@@ -29,7 +29,7 @@ export const styles = {
     minHeight: cellMinHeight,
     borderBottom: '1px solid white',
   },
-};
+});
 
 /*
  * 0 is 12am
@@ -53,7 +53,8 @@ export function formatHour(hour) {
   throw new RangeError('Invalid input. hour must be in the range [0, 24]');
 }
 
-function HoursColumn({ hours, classes }) {
+export default function HoursColumn({ hours }) {
+  const classes = useStyles();
   return (
     <div className={classes.hoursColumnContainer}>
       <div className={classes.hoursSpacer} />
@@ -70,9 +71,4 @@ function HoursColumn({ hours, classes }) {
 
 HoursColumn.propTypes = {
   hours: PropTypes.arrayOf(PropTypes.number).isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
-
-export { HoursColumn as UnstyledHoursColumn };
-
-export default withStyles(styles)(HoursColumn);

--- a/src/components/calendar/HoursColumn.test.js
+++ b/src/components/calendar/HoursColumn.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles } from 'util/testing';
-import { formatHour, UnstyledHoursColumn, styles } from './HoursColumn';
+import HoursColumn, { formatHour } from './HoursColumn';
 
 describe('formatHour', () => {
   it('returns 12am when given 0 or 24', () => {
@@ -28,8 +27,7 @@ describe('formatHour', () => {
 
 describe('HoursColumn', () => {
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledHoursColumn hours={[1, 2]} classes={classes} />);
+    const wrapper = shallow(<HoursColumn hours={[1, 2]} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/calendar/__snapshots__/AssociatedClass.test.js.snap
+++ b/src/components/calendar/__snapshots__/AssociatedClass.test.js.snap
@@ -5,22 +5,34 @@ exports[`AssociatedClass renders correctly 1`] = `
   <Section
     classes={
       Object {
-        "container": "",
-        "header": "",
-        "paper": "",
-        "text": "",
+        "container": "makeStyles-container-2",
+        "header": "makeStyles-header-4",
+        "paper": "makeStyles-paper-1 makeStyles-paper-5",
+        "text": "makeStyles-text-3",
       }
     }
     leftHeaderContent="left hand header content"
     onClick={[Function]}
     rightHeaderContent="EECS 111-0"
-    sectionName="DIS - undefined"
+    sectionName="undefined - undefined"
   />
   <ClassModal
     associatedClass={
       Object {
-        "name": "Some discussion",
-        "type": "DIS",
+        "color": "some color",
+        "column": 0,
+        "columnWidth": 1,
+        "event": Object {
+          "dow": "Mo",
+          "end": Object {
+            "hour": 12,
+            "minute": 0,
+          },
+          "start": Object {
+            "hour": 10,
+            "minute": 30,
+          },
+        },
       }
     }
     section={

--- a/src/components/calendar/__snapshots__/CalendarSection.test.js.snap
+++ b/src/components/calendar/__snapshots__/CalendarSection.test.js.snap
@@ -5,10 +5,10 @@ exports[`CalendarSection renders correctly 1`] = `
   <Section
     classes={
       Object {
-        "container": "",
-        "header": "",
-        "paper": "",
-        "text": "",
+        "container": "makeStyles-container-2",
+        "header": "makeStyles-header-4",
+        "paper": "makeStyles-paper-1 makeStyles-paper-5",
+        "text": "makeStyles-text-3",
       }
     }
     leftHeaderContent="10:30 - 12:00"

--- a/src/components/calendar/__snapshots__/CalendarView.test.js.snap
+++ b/src/components/calendar/__snapshots__/CalendarView.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`CalendarView renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-calendarRoot-1"
 >
-  <ForwardRef(WithStyles)
+  <HoursColumn
     hours={
       Array [
         8,
@@ -26,21 +26,21 @@ exports[`CalendarView renders correctly 1`] = `
     }
   />
   <div
-    className=""
+    className="makeStyles-dowColumns-2"
   >
-    <ForwardRef(WithStyles)
+    <DowColumn
       dow="Mo"
     />
-    <ForwardRef(WithStyles)
+    <DowColumn
       dow="Tu"
     />
-    <ForwardRef(WithStyles)
+    <DowColumn
       dow="We"
     />
-    <ForwardRef(WithStyles)
+    <DowColumn
       dow="Th"
     />
-    <ForwardRef(WithStyles)
+    <DowColumn
       dow="Fr"
     />
   </div>

--- a/src/components/calendar/__snapshots__/DowColumn.test.js.snap
+++ b/src/components/calendar/__snapshots__/DowColumn.test.js.snap
@@ -2,75 +2,75 @@
 
 exports[`DowColumn renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-dowColumn-1"
 >
   <ForwardRef(WithStyles)
     align="center"
-    className=""
+    className="makeStyles-dowHeader-2"
     variant="body1"
   >
     
   </ForwardRef(WithStyles)>
   <div
-    className=""
+    className="makeStyles-calendarColumn-3"
   >
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={8}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={9}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={10}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={11}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={12}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={13}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={14}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={15}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={16}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={17}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={18}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={19}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={20}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={21}
     />
-    <ForwardRef(WithStyles)
+    <HourCell
       dow="Mon"
       hour={22}
     />

--- a/src/components/calendar/__snapshots__/HourCell.test.js.snap
+++ b/src/components/calendar/__snapshots__/HourCell.test.js.snap
@@ -2,19 +2,27 @@
 
 exports[`HourCell renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-calendarCell-1"
 >
-  <ForwardRef(WithStyles)
+  <CalendarSection
+    isPreview={false}
     section={
       Object {
         "id": "12345",
       }
     }
   />
-  <ForwardRef(WithStyles)
+  <AssociatedClass
     associatedClass={
       Object {
         "event": Object {},
+        "sectionId": "12345",
+      }
+    }
+    isPreview={false}
+    section={
+      Object {
+        "id": "12345",
       }
     }
   />

--- a/src/components/calendar/__snapshots__/HoursColumn.test.js.snap
+++ b/src/components/calendar/__snapshots__/HoursColumn.test.js.snap
@@ -2,23 +2,23 @@
 
 exports[`HoursColumn renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-hoursColumnContainer-1"
 >
   <div
-    className=""
+    className="makeStyles-hoursSpacer-2"
   />
   <div
-    className=""
+    className="makeStyles-hoursColumn-3"
   >
     <ForwardRef(WithStyles)
       align="right"
-      className=""
+      className="makeStyles-hours-4"
     >
       1am
     </ForwardRef(WithStyles)>
     <ForwardRef(WithStyles)
       align="right"
-      className=""
+      className="makeStyles-hours-4"
     >
       2am
     </ForwardRef(WithStyles)>

--- a/src/components/pages/AboutPage.js
+++ b/src/components/pages/AboutPage.js
@@ -1,8 +1,7 @@
 import React from 'react';
 import { northwesternPurple10 } from 'util/colors';
-import PropTypes from 'prop-types';
 import { Typography, Paper } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import heroImage from 'images/hero-image.jpg';
 import studentImage from 'images/surprised_student.svg';
 import joonProfile from 'images/joon.jpeg';
@@ -14,7 +13,7 @@ import amyProfile from 'images/amy.jpg';
 
 const heroHeight = 600;
 
-export const styles = {
+const useStyles = makeStyles({
   hero: {
     backgroundImage: `url(${heroImage})`,
     minHeight: heroHeight,
@@ -72,9 +71,11 @@ export const styles = {
     width: '250px',
     margin: '10px',
   },
-};
+});
 
-function AboutPage({ classes }) {
+export default function AboutPage() {
+  const classes = useStyles();
+
   return (
     <div>
       <div className={classes.hero} />
@@ -173,10 +174,3 @@ function AboutPage({ classes }) {
     </div>
   );
 }
-
-AboutPage.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { AboutPage as UnstyledAboutPage };
-export default withStyles(styles)(AboutPage);

--- a/src/components/pages/AboutPage.test.js
+++ b/src/components/pages/AboutPage.test.js
@@ -1,5 +1,6 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledAboutPage, styles } from './AboutPage';
+import React from 'react';
+import { shallow } from 'enzyme';
+import AboutPage from './AboutPage';
 
 jest.mock('images/hero-image.jpg');
 jest.mock('images/amy.jpg');
@@ -12,10 +13,8 @@ jest.mock('images/madison.jpg');
 jest.mock('images/surprised_student.svg');
 
 describe('AboutPage', () => {
-  const getWrapper = wrapperCreator(UnstyledAboutPage, undefined, styles);
-
   it('should render correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<AboutPage />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/pages/BugReportPage.js
+++ b/src/components/pages/BugReportPage.js
@@ -1,17 +1,17 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { Typography, Button } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { pageContainer, pageBody } from './common/styles';
 import PageTitle from './common/PageTitle';
 
-export const styles = {
+const useStyles = makeStyles({
   pageContainer,
   pageBody,
-};
+});
 
-function BugReportPage({ classes }) {
+export default function BugReportPage() {
   const [userHasAcknowledgedMessage, setUserHasAcknowledgeMessage] = useState(false);
+  const classes = useStyles();
   return (
     <div className={classes.pageContainer}>
       <PageTitle title="Report a Bug" />
@@ -44,10 +44,3 @@ function BugReportPage({ classes }) {
     </div>
   );
 }
-
-BugReportPage.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { BugReportPage as UnstyledBugReportPage };
-export default withStyles(styles)(BugReportPage);

--- a/src/components/pages/BugReportPage.test.js
+++ b/src/components/pages/BugReportPage.test.js
@@ -1,18 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { Button } from '@material-ui/core';
-import { wrapperCreator } from 'util/testing';
-import { UnstyledBugReportPage, styles } from './BugReportPage';
+import BugReportPage from './BugReportPage';
 
 describe('BugReportPage', () => {
-  const getWrapper = wrapperCreator(UnstyledBugReportPage, undefined, styles);
-
   it('should render correctly before user acknowledgement', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<BugReportPage />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('should render correctly after user acknowledgement', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<BugReportPage />);
 
     wrapper.find(Button).simulate('click');
 

--- a/src/components/pages/ContactPage.js
+++ b/src/components/pages/ContactPage.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Typography, Icon } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import facebookLogo from 'images/facebook-logo.png';
 import { pageContainer, pageBody } from './common/styles';
 import PageTitle from './common/PageTitle';
 
-export const styles = {
+const useStyles = makeStyles({
   pageContainer,
   pageBody,
   contactMethod: {
@@ -20,9 +19,10 @@ export const styles = {
   facebookLogo: {
     width: 36, // width of large icon (email)
   },
-};
+});
 
-function ContactPage({ classes }) {
+export default function ContactPage() {
+  const classes = useStyles();
   return (
     <div className={classes.pageContainer}>
       <PageTitle title="Contact Us" />
@@ -49,10 +49,3 @@ function ContactPage({ classes }) {
     </div>
   );
 }
-
-ContactPage.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { ContactPage as UnstyledContactPage };
-export default withStyles(styles)(ContactPage);

--- a/src/components/pages/ContactPage.test.js
+++ b/src/components/pages/ContactPage.test.js
@@ -1,13 +1,12 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledContactPage, styles } from './ContactPage';
+import React from 'react';
+import { shallow } from 'enzyme';
+import ContactPage from './ContactPage';
 
 jest.mock('images/facebook-logo.png');
 
 describe('ContactPage', () => {
-  const getWrapper = wrapperCreator(UnstyledContactPage, undefined, styles);
-
   it('should render correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<ContactPage />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/pages/FAQPage.js
+++ b/src/components/pages/FAQPage.js
@@ -1,20 +1,20 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { pageContainer, pageBody } from './common/styles';
 import PageTitle from './common/PageTitle';
 
-export const styles = {
+const useStyles = makeStyles({
   pageContainer,
   pageBody,
   question: {
     marginBottom: 30,
   },
-};
+});
 
-function FAQPage({ classes }) {
+export default function FAQPage() {
+  const classes = useStyles();
   return (
     <div className={classes.pageContainer}>
       <PageTitle title="Frequently Asked Questions" />
@@ -96,10 +96,3 @@ function FAQPage({ classes }) {
     </div>
   );
 }
-
-FAQPage.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { FAQPage as UnstyledFAQPage };
-export default withStyles(styles)(FAQPage);

--- a/src/components/pages/FAQPage.test.js
+++ b/src/components/pages/FAQPage.test.js
@@ -1,11 +1,10 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledFAQPage, styles } from './FAQPage';
+import React from 'react';
+import { shallow } from 'enzyme';
+import FAQPage from './FAQPage';
 
 describe('FAQPage', () => {
-  const getWrapper = wrapperCreator(UnstyledFAQPage, undefined, styles);
-
   it('should render correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<FAQPage />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/pages/LegalPage.js
+++ b/src/components/pages/LegalPage.js
@@ -1,19 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { pageContainer, pageBody } from './common/styles';
 import PageTitle from './common/PageTitle';
 
-export const styles = {
+const useStyles = makeStyles({
   pageContainer,
   pageBody,
   section: {
     margin: '30px 0',
   },
-};
+});
 
-function LegalPage({ classes }) {
+export default function LegalPage() {
+  const classes = useStyles();
   return (
     <div className={classes.pageContainer}>
       <PageTitle title="Serif.nu - Legal" />
@@ -153,10 +153,3 @@ function LegalPage({ classes }) {
     </div>
   );
 }
-
-LegalPage.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { LegalPage as UnstyledLegalPage };
-export default withStyles(styles)(LegalPage);

--- a/src/components/pages/LegalPage.test.js
+++ b/src/components/pages/LegalPage.test.js
@@ -1,11 +1,10 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledLegalPage, styles } from './LegalPage';
+import React from 'react';
+import { shallow } from 'enzyme';
+import LegalPage from './LegalPage';
 
 describe('LegalPage', () => {
-  const getWrapper = wrapperCreator(UnstyledLegalPage, undefined, styles);
-
   it('should render correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<LegalPage />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/pages/__snapshots__/AboutPage.test.js.snap
+++ b/src/components/pages/__snapshots__/AboutPage.test.js.snap
@@ -3,10 +3,10 @@
 exports[`AboutPage should render correctly 1`] = `
 <div>
   <div
-    className=""
+    className="makeStyles-hero-1"
   />
   <div
-    className=""
+    className="makeStyles-heroText-2"
   >
     <ForwardRef(WithStyles)
       color="inherit"
@@ -15,40 +15,40 @@ exports[`AboutPage should render correctly 1`] = `
       Simple. Fast. Visual.
     </ForwardRef(WithStyles)>
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-heroSubtitle-3"
       variant="h5"
     >
       Course planning for Northwestern University.
     </ForwardRef(WithStyles)>
   </div>
   <div
-    className=""
+    className="makeStyles-section-6"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-header-4"
       color="primary"
       variant="h3"
     >
       Serif.nu redefines your scheduling experience.
     </ForwardRef(WithStyles)>
     <div
-      className=""
+      className="makeStyles-multipleColumns-8"
     >
       <div>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
           variant="h5"
         >
           No more drawing out your schedules on paper.
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
           variant="h5"
         >
           No more clunkly Excel spreadsheets.
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
           variant="h5"
         >
           Plan out your next quarter at Northwestern with ease and speed.
@@ -56,37 +56,37 @@ exports[`AboutPage should render correctly 1`] = `
       </div>
       <img
         alt="Student with a laptop"
-        className=""
+        className="makeStyles-studentImage-9"
         src={Object {}}
       />
     </div>
   </div>
   <div
-    className=""
+    className="makeStyles-sectionWithColor-7"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-header-4"
       color="primary"
       variant="h3"
     >
       The Team
     </ForwardRef(WithStyles)>
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-blurbs-5"
       variant="h5"
     >
       Serif.nu is run by a team of previous and current Northwestern students dedicated to providing the best scheduling experience.
     </ForwardRef(WithStyles)>
     <div
-      className=""
+      className="makeStyles-multipleColumns-8"
     >
       <ForwardRef(WithStyles)
-        className=""
+        className="makeStyles-studentCard-10"
         elevation={2}
       >
         <img
           alt="Joon Park"
-          className=""
+          className="makeStyles-profileImage-11"
           src={Object {}}
         />
         <ForwardRef(WithStyles)
@@ -100,18 +100,18 @@ exports[`AboutPage should render correctly 1`] = `
           Creator & Team Lead
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
         >
           Software engineer at Grubhub, film composer in another life. Big fan of taking pictures that make me look like I'm falling off of things.
         </ForwardRef(WithStyles)>
       </ForwardRef(WithStyles)>
       <ForwardRef(WithStyles)
-        className=""
+        className="makeStyles-studentCard-10"
         elevation={2}
       >
         <img
           alt="Kevin Lee"
-          className=""
+          className="makeStyles-profileImage-11"
           src={Object {}}
         />
         <ForwardRef(WithStyles)
@@ -125,18 +125,18 @@ exports[`AboutPage should render correctly 1`] = `
           Lead Student Developer
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
         >
           Senior studying computer science...and nothing else! Strong enthusiast of deep dish pizza, the color turquoise, and Korean music.
         </ForwardRef(WithStyles)>
       </ForwardRef(WithStyles)>
       <ForwardRef(WithStyles)
-        className=""
+        className="makeStyles-studentCard-10"
         elevation={2}
       >
         <img
           alt="Madison Dong"
-          className=""
+          className="makeStyles-profileImage-11"
           src={Object {}}
         />
         <ForwardRef(WithStyles)
@@ -150,18 +150,18 @@ exports[`AboutPage should render correctly 1`] = `
           Student Developer
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
         >
           Madison Dong is a (soon-to-be) junior studying journalism, computer science, and design, so she thinks art and tech go well together. Her three pillars of life are: adventures with friends, 7-Eleven Big Bite hot dogs, and Frank Ocean. Send her funny emails and/or articles: madisonfdong@gmail.com
         </ForwardRef(WithStyles)>
       </ForwardRef(WithStyles)>
       <ForwardRef(WithStyles)
-        className=""
+        className="makeStyles-studentCard-10"
         elevation={2}
       >
         <img
           alt="Julia Tournant"
-          className=""
+          className="makeStyles-profileImage-11"
           src={Object {}}
         />
         <ForwardRef(WithStyles)
@@ -175,18 +175,18 @@ exports[`AboutPage should render correctly 1`] = `
           Student Developer
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
         >
           Hi! I’m Julia. I’m French, currently 19 years old, and will graduate in June 2021. I study computer science and enjoy learning foreign languages. I’m also a member of the varsity golf team here at NU! You can reach out to me at juliatournant2021@u.northwestern.edu.
         </ForwardRef(WithStyles)>
       </ForwardRef(WithStyles)>
       <ForwardRef(WithStyles)
-        className=""
+        className="makeStyles-studentCard-10"
         elevation={2}
       >
         <img
           alt="Helen Zhao"
-          className=""
+          className="makeStyles-profileImage-11"
           src={Object {}}
         />
         <ForwardRef(WithStyles)
@@ -200,7 +200,7 @@ exports[`AboutPage should render correctly 1`] = `
           Student Developer
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
         >
           I am Helen, a Northwestern sophomore. Love cooking, love taekwondo and especially love watching dogs sneeze
           <span
@@ -212,12 +212,12 @@ exports[`AboutPage should render correctly 1`] = `
         </ForwardRef(WithStyles)>
       </ForwardRef(WithStyles)>
       <ForwardRef(WithStyles)
-        className=""
+        className="makeStyles-studentCard-10"
         elevation={2}
       >
         <img
           alt="Amy Chen"
-          className=""
+          className="makeStyles-profileImage-11"
           src={Object {}}
         />
         <ForwardRef(WithStyles)
@@ -231,7 +231,7 @@ exports[`AboutPage should render correctly 1`] = `
           Student Developer
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)
-          className=""
+          className="makeStyles-blurbs-5"
         >
           My name is Amy and I'm majoring in Statistics, Economics, and MMSS. I'm pursuing a career in software engineering. Outside of school, I love tennis and photography!
         </ForwardRef(WithStyles)>

--- a/src/components/pages/__snapshots__/BugReportPage.test.js.snap
+++ b/src/components/pages/__snapshots__/BugReportPage.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`BugReportPage should render correctly after user acknowledgement 1`] = `
 <div
-  className=""
+  className="makeStyles-pageContainer-1"
 >
-  <ForwardRef(WithStyles)
+  <PageTitle
     title="Report a Bug"
   />
   <div
-    className=""
+    className="makeStyles-pageBody-2"
   >
     <iframe
       frameBorder="0"
@@ -27,13 +27,13 @@ exports[`BugReportPage should render correctly after user acknowledgement 1`] = 
 
 exports[`BugReportPage should render correctly before user acknowledgement 1`] = `
 <div
-  className=""
+  className="makeStyles-pageContainer-1"
 >
-  <ForwardRef(WithStyles)
+  <PageTitle
     title="Report a Bug"
   />
   <div
-    className=""
+    className="makeStyles-pageBody-2"
   >
     <div>
       <ForwardRef(WithStyles)

--- a/src/components/pages/__snapshots__/ContactPage.test.js.snap
+++ b/src/components/pages/__snapshots__/ContactPage.test.js.snap
@@ -2,19 +2,19 @@
 
 exports[`ContactPage should render correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-pageContainer-1"
 >
-  <ForwardRef(WithStyles)
+  <PageTitle
     title="Contact Us"
   />
   <div
-    className=""
+    className="makeStyles-pageBody-2"
   >
     <div
-      className=""
+      className="makeStyles-contactMethod-3"
     >
       <a
-        className=""
+        className="makeStyles-contactLink-4"
         href="mailto:serifnorthwestern@gmail.com"
       >
         <ForwardRef(WithStyles)
@@ -31,15 +31,15 @@ exports[`ContactPage should render correctly 1`] = `
       </ForwardRef(WithStyles)>
     </div>
     <div
-      className=""
+      className="makeStyles-contactMethod-3"
     >
       <a
-        className=""
+        className="makeStyles-contactLink-4"
         href="https://www.facebook.com/serifnorthwestern"
       >
         <img
           alt="Facebook logo"
-          className=""
+          className="makeStyles-facebookLogo-5"
           src={Object {}}
         />
       </a>

--- a/src/components/pages/__snapshots__/FAQPage.test.js.snap
+++ b/src/components/pages/__snapshots__/FAQPage.test.js.snap
@@ -2,16 +2,16 @@
 
 exports[`FAQPage should render correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-pageContainer-1"
 >
-  <ForwardRef(WithStyles)
+  <PageTitle
     title="Frequently Asked Questions"
   />
   <div
-    className=""
+    className="makeStyles-pageBody-2"
   >
     <div
-      className=""
+      className="makeStyles-question-3"
     >
       <ForwardRef(WithStyles)
         gutterBottom={true}
@@ -33,7 +33,7 @@ exports[`FAQPage should render correctly 1`] = `
       </ForwardRef(WithStyles)>
     </div>
     <div
-      className=""
+      className="makeStyles-question-3"
     >
       <ForwardRef(WithStyles)
         gutterBottom={true}
@@ -60,7 +60,7 @@ exports[`FAQPage should render correctly 1`] = `
       </ForwardRef(WithStyles)>
     </div>
     <div
-      className=""
+      className="makeStyles-question-3"
     >
       <ForwardRef(WithStyles)
         gutterBottom={true}
@@ -75,7 +75,7 @@ exports[`FAQPage should render correctly 1`] = `
       </ForwardRef(WithStyles)>
     </div>
     <div
-      className=""
+      className="makeStyles-question-3"
     >
       <ForwardRef(WithStyles)
         gutterBottom={true}
@@ -105,7 +105,7 @@ exports[`FAQPage should render correctly 1`] = `
       </ForwardRef(WithStyles)>
     </div>
     <div
-      className=""
+      className="makeStyles-question-3"
     >
       <ForwardRef(WithStyles)
         gutterBottom={true}

--- a/src/components/pages/__snapshots__/LegalPage.test.js.snap
+++ b/src/components/pages/__snapshots__/LegalPage.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`LegalPage should render correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-pageContainer-1"
 >
-  <ForwardRef(WithStyles)
+  <PageTitle
     title="Serif.nu - Legal"
   />
   <div
-    className=""
+    className="makeStyles-pageBody-2"
   >
     <ForwardRef(WithStyles)
       variant="body1"
@@ -27,7 +27,7 @@ exports[`LegalPage should render correctly 1`] = `
       Serif.nu is not created by Northwestern University.
     </ForwardRef(WithStyles)>
     <div
-      className=""
+      className="makeStyles-section-3"
     >
       <ForwardRef(WithStyles)
         variant="h4"
@@ -122,7 +122,7 @@ exports[`LegalPage should render correctly 1`] = `
       </ol>
     </div>
     <div
-      className=""
+      className="makeStyles-section-3"
     >
       <ForwardRef(WithStyles)
         gutterBottom={true}

--- a/src/components/pages/__snapshots__/NotFoundPage.test.js.snap
+++ b/src/components/pages/__snapshots__/NotFoundPage.test.js.snap
@@ -4,7 +4,7 @@ exports[`FAQPage should render correctly 1`] = `
 <div
   className="makeStyles-pageContainer-1"
 >
-  <ForwardRef(WithStyles)
+  <PageTitle
     title="404 Page Not Found"
   />
   <div

--- a/src/components/pages/common/PageTitle.js
+++ b/src/components/pages/common/PageTitle.js
@@ -1,19 +1,19 @@
 import React from 'react';
 import { northwesternPurple10 } from 'util/colors';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { Typography } from '@material-ui/core';
 
-export const styles = {
+const useStyles = makeStyles({
   page: {
     margin: 20,
     padding: 5,
     borderBottom: `2px solid ${northwesternPurple10}`,
   },
-};
+});
 
-
-function PageTitle({ classes, title }) {
+export default function PageTitle({ title }) {
+  const classes = useStyles();
   return (
     <div className={classes.page}>
       <Typography variant="h3" color="primary">
@@ -24,9 +24,5 @@ function PageTitle({ classes, title }) {
 }
 
 PageTitle.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
   title: PropTypes.string.isRequired,
 };
-
-export { PageTitle as UnstyledPageTitle };
-export default withStyles(styles)(PageTitle);

--- a/src/components/pages/common/PageTitle.test.js
+++ b/src/components/pages/common/PageTitle.test.js
@@ -1,14 +1,14 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledPageTitle, styles } from './PageTitle';
+import React from 'react';
+import { shallow } from 'enzyme';
+import PageTitle from './PageTitle';
 
 describe('PageTitle', () => {
   const defaultProps = {
     title: 'Title',
   };
-  const getComponent = wrapperCreator(UnstyledPageTitle, defaultProps, styles);
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<PageTitle {...defaultProps} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/pages/common/__snapshots__/PageTitle.test.js.snap
+++ b/src/components/pages/common/__snapshots__/PageTitle.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`PageTitle renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-page-1"
 >
   <ForwardRef(WithStyles)
     color="primary"

--- a/src/components/sidebar/SidebarHeader.js
+++ b/src/components/sidebar/SidebarHeader.js
@@ -1,9 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { Typography, Button, Divider } from '@material-ui/core';
 
-export const styles = {
+const useStyles = makeStyles({
   sectionsRoot: {
     padding: 16,
   },
@@ -15,9 +15,10 @@ export const styles = {
   divider: {
     marginTop: 5,
   },
-};
+});
 
-function SidebarHeader({ classes, title, back }) {
+export default function SidebarHeader({ title, back }) {
+  const classes = useStyles();
   return (
     <Fragment>
       <Typography variant="h5" className={classes.title}>
@@ -31,10 +32,6 @@ function SidebarHeader({ classes, title, back }) {
 }
 
 SidebarHeader.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
   title: PropTypes.string.isRequired,
   back: PropTypes.func.isRequired,
 };
-
-export { SidebarHeader as UnstyledSidebarHeader };
-export default withStyles(styles)(SidebarHeader);

--- a/src/components/sidebar/SidebarHeader.test.js
+++ b/src/components/sidebar/SidebarHeader.test.js
@@ -1,15 +1,15 @@
-import { wrapperCreator } from 'util/testing';
-import { UnstyledSidebarHeader, styles } from './SidebarHeader';
+import React from 'react';
+import { shallow } from 'enzyme';
+import SidebarHeader from './SidebarHeader';
 
 describe('SidebarHeader', () => {
   const defaultProps = {
     title: 'Title',
     back: () => {},
   };
-  const getComponent = wrapperCreator(UnstyledSidebarHeader, defaultProps, styles);
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<SidebarHeader {...defaultProps} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });

--- a/src/components/sidebar/SidebarView.js
+++ b/src/components/sidebar/SidebarView.js
@@ -1,12 +1,11 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import { Tabs, Tab } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import Search from './search/Search';
 import Cart from './cart/Cart';
 import Browse from './browse/Browse';
 
-export const styles = {
+const useStyles = makeStyles({
   wrapper: {
     height: 'calc(100vh - 64px)', // 64px is height of TopBar
     overflow: 'auto',
@@ -14,9 +13,10 @@ export const styles = {
   tabWidth: {
     minWidth: 0,
   },
-};
+});
 
-function SidebarView({ classes }) {
+export default function SidebarView() {
+  const classes = useStyles();
   const [value, setValue] = useState('search');
 
   return (
@@ -38,10 +38,3 @@ function SidebarView({ classes }) {
     </div>
   );
 }
-
-SidebarView.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { SidebarView as UnstyledSidebarView };
-export default withStyles(styles)(SidebarView);

--- a/src/components/sidebar/SidebarView.test.js
+++ b/src/components/sidebar/SidebarView.test.js
@@ -1,34 +1,26 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Tabs } from '@material-ui/core';
-import { mockStyles } from 'util/testing';
-import { UnstyledSidebarView, styles } from './SidebarView';
+import SidebarView from './SidebarView';
 
 describe('SidebarView', () => {
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledSidebarView
-      classes={classes}
-    />);
+    const wrapper = shallow(<SidebarView />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('changes tabs correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledSidebarView
-      classes={classes}
-    />);
+    const wrapper = shallow(<SidebarView />);
+
     wrapper.find(Tabs).props().onChange('onChange', 'browse');
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('changes to cart correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledSidebarView
-      classes={classes}
-    />);
+    const wrapper = shallow(<SidebarView />);
+
     wrapper.find(Tabs).props().onChange('onChange', 'cart');
 
     expect(wrapper.get(0)).toMatchSnapshot();

--- a/src/components/sidebar/__snapshots__/SidebarHeader.test.js.snap
+++ b/src/components/sidebar/__snapshots__/SidebarHeader.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SidebarHeader renders correctly 1`] = `
 <React.Fragment>
   <ForwardRef(WithStyles)
-    className=""
+    className="makeStyles-title-2"
     variant="h5"
   >
     Title
@@ -14,7 +14,7 @@ exports[`SidebarHeader renders correctly 1`] = `
     </ForwardRef(WithStyles)>
   </ForwardRef(WithStyles)>
   <ForwardRef(WithStyles)
-    className=""
+    className="makeStyles-divider-3"
   />
 </React.Fragment>
 `;

--- a/src/components/sidebar/__snapshots__/SidebarView.test.js.snap
+++ b/src/components/sidebar/__snapshots__/SidebarView.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SidebarView changes tabs correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-wrapper-1"
 >
   <ForwardRef(WithStyles)
     indicatorColor="primary"
@@ -12,17 +12,17 @@ exports[`SidebarView changes tabs correctly 1`] = `
     variant="fullWidth"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Search"
       value="search"
     />
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Browse"
       value="browse"
     />
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Cart"
       value="cart"
     />
@@ -33,7 +33,7 @@ exports[`SidebarView changes tabs correctly 1`] = `
 
 exports[`SidebarView changes to cart correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-wrapper-1"
 >
   <ForwardRef(WithStyles)
     indicatorColor="primary"
@@ -43,28 +43,28 @@ exports[`SidebarView changes to cart correctly 1`] = `
     variant="fullWidth"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Search"
       value="search"
     />
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Browse"
       value="browse"
     />
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Cart"
       value="cart"
     />
   </ForwardRef(WithStyles)>
-  <ForwardRef(WithStyles) />
+  <Cart />
 </div>
 `;
 
 exports[`SidebarView renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-wrapper-1"
 >
   <ForwardRef(WithStyles)
     indicatorColor="primary"
@@ -74,17 +74,17 @@ exports[`SidebarView renders correctly 1`] = `
     variant="fullWidth"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Search"
       value="search"
     />
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Browse"
       value="browse"
     />
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-tabWidth-2"
       label="Cart"
       value="cart"
     />

--- a/src/components/sidebar/browse/BrowseHeader.js
+++ b/src/components/sidebar/browse/BrowseHeader.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { Typography, Button } from '@material-ui/core';
 import useSelector from 'util/use-selector';
 import {
@@ -11,7 +10,7 @@ import {
 } from 'selectors';
 import { changeBrowseLevel } from 'actions';
 
-export const styles = {
+const useStyles = makeStyles({
   browseHeader: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -23,9 +22,10 @@ export const styles = {
   backButton: {
     padding: '10px 16px',
   },
-};
+});
 
-function BrowseHeader({ classes }) {
+export default function BrowseHeader() {
+  const classes = useStyles();
   const currentBrowseLevel = useSelector(currentBrowseLevelSelector);
   const selectedSchoolId = useSelector(selectedSchoolIdSelector);
   const selectedSubjectId = useSelector(selectedSubjectIdSelector);
@@ -64,10 +64,3 @@ function BrowseHeader({ classes }) {
     </div>
   );
 }
-
-BrowseHeader.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { BrowseHeader as UnstyledBrowseHeader };
-export default withStyles(styles)(BrowseHeader);

--- a/src/components/sidebar/browse/BrowseHeader.test.js
+++ b/src/components/sidebar/browse/BrowseHeader.test.js
@@ -1,17 +1,17 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { Typography, Button } from '@material-ui/core';
-import { wrapperCreator, mockUseSelector, mockUseDispatch } from 'util/testing';
+import { mockUseSelector, mockUseDispatch } from 'util/testing';
 import { changeBrowseLevel } from 'actions';
-import { UnstyledBrowseHeader, styles } from './BrowseHeader';
+import BrowseHeader from './BrowseHeader';
 
 describe('BrowseHeader', () => {
-  const getComponent = wrapperCreator(UnstyledBrowseHeader, undefined, styles);
-
   beforeEach(() => {
     mockUseSelector('school', '', '');
   });
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<BrowseHeader />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
@@ -20,7 +20,7 @@ describe('BrowseHeader', () => {
     const selectedSchoolId = '1234';
     mockUseSelector('subject', selectedSchoolId, '');
 
-    const wrapper = getComponent();
+    const wrapper = shallow(<BrowseHeader />);
 
     expect(wrapper.find(Typography).prop('children')).toBe(selectedSchoolId);
   });
@@ -28,7 +28,7 @@ describe('BrowseHeader', () => {
   it('renders correctly for course browse level', () => {
     const selectedSubjectId = 'MEAS';
     mockUseSelector('course', '', selectedSubjectId);
-    const wrapper = getComponent();
+    const wrapper = shallow(<BrowseHeader />);
 
     expect(wrapper.find(Typography).prop('children')).toBe(selectedSubjectId);
   });
@@ -37,7 +37,7 @@ describe('BrowseHeader', () => {
     mockUseSelector('subject', 'WCAS', '');
     const dispatchMock = mockUseDispatch();
 
-    const wrapper = getComponent();
+    const wrapper = shallow(<BrowseHeader />);
 
     wrapper.find(Button).simulate('click');
 
@@ -48,7 +48,7 @@ describe('BrowseHeader', () => {
     mockUseSelector('course', 'EECS', '');
     const dispatchMock = mockUseDispatch();
 
-    const wrapper = getComponent();
+    const wrapper = shallow(<BrowseHeader />);
 
     wrapper.find(Button).simulate('click');
 

--- a/src/components/sidebar/browse/Courses.js
+++ b/src/components/sidebar/browse/Courses.js
@@ -1,18 +1,18 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { List, ListItem, ListItemText, CircularProgress } from '@material-ui/core';
 import { coursesSelector, browseIsFetchingSelector } from 'selectors';
 import { changeBrowseLevel, fetchSectionsForBrowseRequest, selectCourseInBrowse } from 'actions';
 import useSelector from 'util/use-selector';
 import { loadingContainer as loadingContainerStyles } from './common/styles';
 
-export const styles = {
+const useStyles = makeStyles({
   loadingContainer: loadingContainerStyles,
-};
+});
 
-function Courses({ classes }) {
+export default function Courses() {
+  const classes = useStyles();
   const courses = useSelector(coursesSelector);
   const isFetching = useSelector(browseIsFetchingSelector);
   const dispatch = useDispatch();
@@ -47,10 +47,3 @@ function Courses({ classes }) {
     </div>
   );
 }
-
-Courses.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { Courses as UnstyledCourses };
-export default withStyles(styles)(Courses);

--- a/src/components/sidebar/browse/Courses.test.js
+++ b/src/components/sidebar/browse/Courses.test.js
@@ -1,7 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { ListItem } from '@material-ui/core';
-import { wrapperCreator, mockUseSelector, mockUseDispatch } from 'util/testing';
+import { mockUseSelector, mockUseDispatch } from 'util/testing';
 import { changeBrowseLevel, fetchSectionsForBrowseRequest, selectCourseInBrowse } from 'actions';
-import { UnstyledCourses, styles } from './Courses';
+import Courses from './Courses';
 
 describe('Courses', () => {
   const course = {
@@ -12,28 +14,26 @@ describe('Courses', () => {
   };
   const courses = [course];
 
-  const getComponent = wrapperCreator(UnstyledCourses, undefined, styles);
-
   beforeEach(() => {
     mockUseSelector(courses, false);
   });
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<Courses />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('renders loading correctly', () => {
     mockUseSelector(courses, true);
-    const wrapper = getComponent();
+    const wrapper = shallow(<Courses />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('showSections gets called correctly', () => {
     const dispatchMock = mockUseDispatch();
-    const wrapper = getComponent();
+    const wrapper = shallow(<Courses />);
 
     wrapper.find(ListItem).first().simulate('click');
 

--- a/src/components/sidebar/browse/Schools.js
+++ b/src/components/sidebar/browse/Schools.js
@@ -1,18 +1,18 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { List, ListItem, ListItemText, CircularProgress } from '@material-ui/core';
 import { schoolsSelector, browseIsFetchingSelector } from 'selectors';
 import { changeBrowseLevel, fetchSubjectsRequest, selectSchoolInBrowse } from 'actions';
 import useSelector from 'util/use-selector';
 import { loadingContainer as loadingContainerStyles } from './common/styles';
 
-export const styles = {
+const useStyles = makeStyles({
   loadingContainer: loadingContainerStyles,
-};
+});
 
-function Schools({ classes }) {
+export default function Schools() {
+  const classes = useStyles();
   const schools = useSelector(schoolsSelector);
   const isFetching = useSelector(browseIsFetchingSelector);
   const dispatch = useDispatch();
@@ -48,10 +48,3 @@ function Schools({ classes }) {
     </div>
   );
 }
-
-Schools.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { Schools as UnstyledSchools };
-export default withStyles(styles)(Schools);

--- a/src/components/sidebar/browse/Schools.test.js
+++ b/src/components/sidebar/browse/Schools.test.js
@@ -1,7 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { ListItem } from '@material-ui/core';
-import { wrapperCreator, mockUseSelector, mockUseDispatch } from 'util/testing';
+import { mockUseSelector, mockUseDispatch } from 'util/testing';
 import { changeBrowseLevel, fetchSubjectsRequest, selectSchoolInBrowse } from 'actions';
-import { UnstyledSchools, styles } from './Schools';
+import Schools from './Schools';
 
 describe('Schools', () => {
   const testSchools = [{
@@ -14,28 +16,26 @@ describe('Schools', () => {
     term: '4720',
   }];
 
-  const getComponent = wrapperCreator(UnstyledSchools, undefined, styles);
-
   beforeEach(() => {
     mockUseSelector(testSchools, false);
   });
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<Schools />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('renders loading correctly', () => {
     mockUseSelector(testSchools, true);
-    const wrapper = getComponent();
+    const wrapper = shallow(<Schools />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('showSubjects gets called correctly', () => {
     const mockDispatch = mockUseDispatch();
-    const wrapper = getComponent();
+    const wrapper = shallow(<Schools />);
 
     wrapper.find(ListItem).first().simulate('click');
 

--- a/src/components/sidebar/browse/Subjects.js
+++ b/src/components/sidebar/browse/Subjects.js
@@ -1,18 +1,18 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { List, ListItem, ListItemText, CircularProgress } from '@material-ui/core';
 import { subjectsSelector, browseIsFetchingSelector } from 'selectors';
 import { changeBrowseLevel, fetchCoursesRequest, selectSubjectInBrowse } from 'actions';
 import useSelector from 'util/use-selector';
 import { loadingContainer as loadingContainerStyles } from './common/styles';
 
-export const styles = {
+const useStyles = makeStyles({
   loadingContainer: loadingContainerStyles,
-};
+});
 
-function Subjects({ classes }) {
+export default function Subjects() {
+  const classes = useStyles();
   const subjects = useSelector(subjectsSelector);
   const isFetching = useSelector(browseIsFetchingSelector);
   const dispatch = useDispatch();
@@ -49,10 +49,3 @@ function Subjects({ classes }) {
     </div>
   );
 }
-
-Subjects.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { Subjects as UnstyledSubjects };
-export default withStyles(styles)(Subjects);

--- a/src/components/sidebar/browse/Subjects.test.js
+++ b/src/components/sidebar/browse/Subjects.test.js
@@ -1,35 +1,36 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { ListItem } from '@material-ui/core';
-import { wrapperCreator, mockUseSelector, mockUseDispatch } from 'util/testing';
+import { mockUseSelector, mockUseDispatch } from 'util/testing';
 import { changeBrowseLevel, fetchCoursesRequest, selectSubjectInBrowse } from 'actions';
-import { UnstyledSubjects, styles } from './Subjects';
+import Subjects from './Subjects';
 
 describe('Subjects', () => {
   const subject = {
     id: 'EECS',
     schoolId: 'MEAS',
   };
-  const getComponent = wrapperCreator(UnstyledSubjects, undefined, styles);
 
   beforeEach(() => {
     mockUseSelector([subject], false);
   });
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<Subjects />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('renders correctly when fetching', () => {
     mockUseSelector([subject], true);
-    const wrapper = getComponent();
+    const wrapper = shallow(<Subjects />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('showCourses gets called correctly', () => {
     const mockDispatch = mockUseDispatch();
-    const wrapper = getComponent();
+    const wrapper = shallow(<Subjects />);
 
     wrapper.find(ListItem).first().simulate('click');
 

--- a/src/components/sidebar/browse/__snapshots__/Browse.test.js.snap
+++ b/src/components/sidebar/browse/__snapshots__/Browse.test.js.snap
@@ -8,15 +8,15 @@ exports[`Browse renders associated classes correctly 1`] = `
 
 exports[`Browse renders courses correctly 1`] = `
 <React.Fragment>
+  <BrowseHeader />
   <ForwardRef(WithStyles) />
-  <ForwardRef(WithStyles) />
-  <ForwardRef(WithStyles) />
+  <Courses />
 </React.Fragment>
 `;
 
 exports[`Browse renders schools correctly 1`] = `
 <React.Fragment>
-  <ForwardRef(WithStyles) />
+  <Schools />
 </React.Fragment>
 `;
 
@@ -28,8 +28,8 @@ exports[`Browse renders sections correctly 1`] = `
 
 exports[`Browse renders subjects correctly 1`] = `
 <React.Fragment>
+  <BrowseHeader />
   <ForwardRef(WithStyles) />
-  <ForwardRef(WithStyles) />
-  <ForwardRef(WithStyles) />
+  <Subjects />
 </React.Fragment>
 `;

--- a/src/components/sidebar/browse/__snapshots__/BrowseAssociatedClassesSelectionContainer.test.js.snap
+++ b/src/components/sidebar/browse/__snapshots__/BrowseAssociatedClassesSelectionContainer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BrowseAssociatedClassesSelectionContainer renders correctly 1`] = `
-<ForwardRef(WithStyles)
+<AssociatedClassesSelection
   addSectionWithAssociatedClass={[Function]}
   associatedClassHover={[Function]}
   associatedClassHoverOff={[Function]}

--- a/src/components/sidebar/browse/__snapshots__/BrowseHeader.test.js.snap
+++ b/src/components/sidebar/browse/__snapshots__/BrowseHeader.test.js.snap
@@ -2,17 +2,17 @@
 
 exports[`BrowseHeader renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-browseHeader-1"
 >
   <div
-    className=""
+    className="makeStyles-selectionName-2"
   >
     <ForwardRef(WithStyles)
       variant="h5"
     />
   </div>
   <div
-    className=""
+    className="makeStyles-backButton-3"
   >
     <ForwardRef(WithStyles)
       onClick={[Function]}

--- a/src/components/sidebar/browse/__snapshots__/BrowseSectionSelectionContainer.test.js.snap
+++ b/src/components/sidebar/browse/__snapshots__/BrowseSectionSelectionContainer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BrowseSectionSelectionContainer renders correctly 1`] = `
-<ForwardRef(WithStyles)
+<SectionSelection
   addSection={[Function]}
   back={[Function]}
   currentCourseName="course name"

--- a/src/components/sidebar/browse/__snapshots__/Courses.test.js.snap
+++ b/src/components/sidebar/browse/__snapshots__/Courses.test.js.snap
@@ -17,7 +17,7 @@ exports[`Courses renders correctly 1`] = `
 
 exports[`Courses renders loading correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-loadingContainer-1"
 >
   <ForwardRef(WithStyles) />
 </div>

--- a/src/components/sidebar/browse/__snapshots__/Schools.test.js.snap
+++ b/src/components/sidebar/browse/__snapshots__/Schools.test.js.snap
@@ -25,7 +25,7 @@ exports[`Schools renders correctly 1`] = `
 
 exports[`Schools renders loading correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-loadingContainer-1"
 >
   <ForwardRef(WithStyles) />
 </div>

--- a/src/components/sidebar/browse/__snapshots__/Subjects.test.js.snap
+++ b/src/components/sidebar/browse/__snapshots__/Subjects.test.js.snap
@@ -17,7 +17,7 @@ exports[`Subjects renders correctly 1`] = `
 
 exports[`Subjects renders correctly when fetching 1`] = `
 <div
-  className=""
+  className="makeStyles-loadingContainer-1"
 >
   <ForwardRef(WithStyles) />
 </div>

--- a/src/components/sidebar/cart/Cart.js
+++ b/src/components/sidebar/cart/Cart.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
-import PropTypes from 'prop-types';
 import { Typography } from '@material-ui/core';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { sectionsSelector } from 'selectors';
 import { useDispatch } from 'react-redux';
 import useSelector from 'util/use-selector';
@@ -11,13 +10,14 @@ import { removeAllClasses } from 'actions';
 import CartSection from './CartSection';
 
 
-export const styles = {
+const useStyles = makeStyles({
   cartHeading: {
     padding: '16px',
   },
-};
+});
 
-function Cart({ classes }) {
+export default function Cart() {
+  const classes = useStyles();
   const sections = useSelector(sectionsSelector);
   const dispatch = useDispatch();
 
@@ -52,10 +52,3 @@ function Cart({ classes }) {
     </React.Fragment>
   );
 }
-
-Cart.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { Cart as UnstyledCart };
-export default withStyles(styles)(Cart);

--- a/src/components/sidebar/cart/Cart.test.js
+++ b/src/components/sidebar/cart/Cart.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles, mockUseSelector, mockUseDispatch } from 'util/testing';
+import { mockUseSelector, mockUseDispatch } from 'util/testing';
 import { Button } from '@material-ui/core';
 import { removeAllClasses } from 'actions';
-import { UnstyledCart, styles } from './Cart';
+import Cart from './Cart';
 
 describe('Cart', () => {
   beforeEach(() => {
@@ -11,8 +11,7 @@ describe('Cart', () => {
   });
 
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledCart classes={classes} />);
+    const wrapper = shallow(<Cart />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
@@ -20,8 +19,7 @@ describe('Cart', () => {
   it('renders correctly with one section', () => {
     mockUseSelector([{ id: '12345' }]);
 
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledCart classes={classes} />);
+    const wrapper = shallow(<Cart />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
@@ -29,8 +27,7 @@ describe('Cart', () => {
   it('renders correctly with multiple sections with the same id', () => {
     mockUseSelector([{ id: '123' }, { id: '123' }]);
 
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledCart classes={classes} />);
+    const wrapper = shallow(<Cart />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
@@ -38,8 +35,7 @@ describe('Cart', () => {
   it('closes removes all classes when clicked', () => {
     mockUseSelector([{ id: '123' }, { id: '123' }]);
     const dispatchMock = mockUseDispatch();
-    const classes = mockStyles(styles);
-    const wrapper = shallow(<UnstyledCart classes={classes} />);
+    const wrapper = shallow(<Cart />);
     wrapper.find(Button).simulate('click');
 
     expect(dispatchMock).toHaveBeenCalledWith(removeAllClasses());

--- a/src/components/sidebar/cart/CartSection.js
+++ b/src/components/sidebar/cart/CartSection.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { getFormattedClassSchedule } from 'util/time';
 import Section from 'components/common/Section';
 import ClassModal from 'components/calendar/ClassModal';
@@ -25,7 +25,10 @@ export const styles = {
   },
 };
 
-function CartSection({ classes, section }) {
+const useStyles = makeStyles(styles);
+
+export default function CartSection({ section }) {
+  const classes = useStyles({ section });
   const [showDialog, setShowDialog] = useState(false);
 
   function toggleDialog() {
@@ -64,8 +67,4 @@ function CartSection({ classes, section }) {
 
 CartSection.propTypes = {
   section: PropTypes.objectOf(PropTypes.any).isRequired, // TODO
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
-
-export { CartSection as UnstyledCartSection };
-export default withStyles(styles)(CartSection);

--- a/src/components/sidebar/cart/CartSection.test.js
+++ b/src/components/sidebar/cart/CartSection.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockStyles } from 'util/testing';
 import * as timeUtils from 'util/time';
 import Section from 'components/common/Section';
 import ClassModal from 'components/calendar/ClassModal';
-import { UnstyledCartSection, styles } from './CartSection';
+import CartSection, { styles } from './CartSection';
 
 describe('CartSection', () => {
   beforeEach(() => {
@@ -21,30 +20,27 @@ describe('CartSection', () => {
   });
 
   it('renders correctly', () => {
-    const classes = mockStyles(styles);
     const testSection = { schedules: [{}], subjectId: 'EECS', courseId: '111-0' };
     const wrapper = shallow(
-      <UnstyledCartSection section={testSection} classes={classes} />,
+      <CartSection section={testSection} />,
     );
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('formats left header content correctly when multiple schedules present', () => {
-    const classes = mockStyles(styles);
     const testSection = { schedules: [{}, {}], subjectId: 'EECS', courseId: '111-0' };
     const wrapper = shallow(
-      <UnstyledCartSection section={testSection} classes={classes} />,
+      <CartSection section={testSection} />,
     );
 
     expect(wrapper.find(Section).prop('leftHeaderContent')).toBe('schedules, schedules');
   });
 
   it('opens modal on click', () => {
-    const classes = mockStyles(styles);
     const testSection = { schedules: [{}], subjectId: 'EECS', courseId: '111-0' };
     const wrapper = shallow(
-      <UnstyledCartSection section={testSection} classes={classes} />,
+      <CartSection section={testSection} />,
     );
 
     wrapper.find(Section).simulate('click');

--- a/src/components/sidebar/cart/__snapshots__/Cart.test.js.snap
+++ b/src/components/sidebar/cart/__snapshots__/Cart.test.js.snap
@@ -8,7 +8,7 @@ exports[`Cart renders correctly 1`] = `
     justify="space-between"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-cartHeading-1"
       variant="h5"
     >
       0
@@ -27,7 +27,7 @@ exports[`Cart renders correctly with multiple sections with the same id 1`] = `
     justify="space-between"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-cartHeading-1"
       variant="h5"
     >
       1
@@ -40,7 +40,7 @@ exports[`Cart renders correctly with multiple sections with the same id 1`] = `
        Remove All 
     </ForwardRef(WithStyles)>
   </ForwardRef(WithStyles)>
-  <ForwardRef(WithStyles)
+  <CartSection
     section={
       Object {
         "id": "123",
@@ -58,7 +58,7 @@ exports[`Cart renders correctly with one section 1`] = `
     justify="space-between"
   >
     <ForwardRef(WithStyles)
-      className=""
+      className="makeStyles-cartHeading-1"
       variant="h5"
     >
       1
@@ -71,7 +71,7 @@ exports[`Cart renders correctly with one section 1`] = `
        Remove All 
     </ForwardRef(WithStyles)>
   </ForwardRef(WithStyles)>
-  <ForwardRef(WithStyles)
+  <CartSection
     section={
       Object {
         "id": "12345",

--- a/src/components/sidebar/cart/__snapshots__/CartSection.test.js.snap
+++ b/src/components/sidebar/cart/__snapshots__/CartSection.test.js.snap
@@ -5,10 +5,10 @@ exports[`CartSection renders correctly 1`] = `
   <Section
     classes={
       Object {
-        "container": "",
-        "header": "",
-        "paper": "",
-        "text": "",
+        "container": "makeStyles-container-2",
+        "header": "makeStyles-header-4",
+        "paper": "makeStyles-paper-1 makeStyles-paper-5",
+        "text": "makeStyles-text-3",
       }
     }
     leftHeaderContent="schedules"

--- a/src/components/sidebar/common/AssociatedClassesSelection.js
+++ b/src/components/sidebar/common/AssociatedClassesSelection.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { List, ListItem, ListItemText, Typography } from '@material-ui/core';
 import { getFormattedClassSchedule, isUnscheduled } from 'util/time';
 import SidebarHeader from '../SidebarHeader';
 
-export const styles = {
+const useStyles = makeStyles({
   sectionsRoot: {
     padding: 16,
   },
@@ -17,9 +17,9 @@ export const styles = {
   divider: {
     marginTop: 5,
   },
-};
+});
 
-function AssociatedClassesSelection({
+export default function AssociatedClassesSelection({
   currentCourseName,
   currentSectionNumber,
   associatedClasses,
@@ -27,8 +27,8 @@ function AssociatedClassesSelection({
   addSectionWithAssociatedClass,
   associatedClassHover,
   associatedClassHoverOff,
-  classes,
 }) {
+  const classes = useStyles();
   return (
     <div className={classes.sectionsRoot}>
       <SidebarHeader title={`${currentCourseName}-${currentSectionNumber}`} back={back} />
@@ -68,11 +68,7 @@ AssociatedClassesSelection.propTypes = {
   currentSectionNumber: PropTypes.string.isRequired,
   associatedClasses: PropTypes.arrayOf(PropTypes.object).isRequired,
   back: PropTypes.func.isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
   addSectionWithAssociatedClass: PropTypes.func.isRequired,
   associatedClassHover: PropTypes.func.isRequired,
   associatedClassHoverOff: PropTypes.func.isRequired,
 };
-
-export { AssociatedClassesSelection as UnstyledAssociatedClassesSelection };
-export default withStyles(styles)(AssociatedClassesSelection);

--- a/src/components/sidebar/common/AssociatedClassesSelection.test.js
+++ b/src/components/sidebar/common/AssociatedClassesSelection.test.js
@@ -1,7 +1,8 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { ListItem, Typography } from '@material-ui/core';
-import { wrapperCreator } from 'util/testing';
 import * as timeUtils from 'util/time';
-import { UnstyledAssociatedClassesSelection, styles } from './AssociatedClassesSelection';
+import AssociatedClassesSelection from './AssociatedClassesSelection';
 
 jest.mock('util/time');
 
@@ -29,22 +30,24 @@ describe('AssociatedClassesSelection', () => {
     associatedClassHover: () => {},
     associatedClassHoverOff: () => {},
   };
-  const getWrapper = wrapperCreator(UnstyledAssociatedClassesSelection, defaultProps, styles);
 
   const formattedSchedule = 'MWF 10 - 12ish';
   timeUtils.getFormattedClassSchedule.mockReturnValue(formattedSchedule);
 
   it('renders correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<AssociatedClassesSelection {...defaultProps} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('adds section with associated class when clicked', () => {
     const addSectionWithAssociatedClassMock = jest.fn();
-    const wrapper = getWrapper({
-      addSectionWithAssociatedClass: addSectionWithAssociatedClassMock,
-    });
+    const wrapper = shallow(
+      <AssociatedClassesSelection
+        {...defaultProps}
+        addSectionWithAssociatedClass={addSectionWithAssociatedClassMock}
+      />,
+    );
     wrapper.find(ListItem).simulate('click');
 
     expect(addSectionWithAssociatedClassMock).toHaveBeenCalledWith(associatedClass);
@@ -52,9 +55,13 @@ describe('AssociatedClassesSelection', () => {
 
   it('calls associatedClassHover when clicked', () => {
     const associatedClassHoverMock = jest.fn();
-    const wrapper = getWrapper({
-      associatedClassHover: associatedClassHoverMock,
-    });
+    const wrapper = shallow(
+      <AssociatedClassesSelection
+        {...defaultProps}
+        associatedClassHover={associatedClassHoverMock}
+      />,
+    );
+
     wrapper.find(ListItem).simulate('mouseEnter');
 
     expect(associatedClassHoverMock).toHaveBeenCalledWith(associatedClass);
@@ -62,16 +69,19 @@ describe('AssociatedClassesSelection', () => {
 
   it('turns scheduled text to red and disables associatedclass if unscheduled', () => {
     timeUtils.isUnscheduled.mockReturnValue(true);
-    const wrapper = getWrapper({
-      associatedClasses: [{
-        type: 'LAB',
-        schedule: {
-          dow: 'TBA',
-          start: 'TBA',
-          end: 'TBA',
-        },
-      }],
-    });
+    const wrapper = shallow(
+      <AssociatedClassesSelection
+        {...defaultProps}
+        associatedClasses={[{
+          type: 'LAB',
+          schedule: {
+            dow: 'TBA',
+            start: 'TBA',
+            end: 'TBA',
+          },
+        }]}
+      />,
+    );
 
     expect(wrapper.find(ListItem).prop('disabled')).toBe(true);
     expect(wrapper.find(Typography).at(1).prop('color')).toBe('error');

--- a/src/components/sidebar/common/SectionSelection.js
+++ b/src/components/sidebar/common/SectionSelection.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { List } from '@material-ui/core';
 import SectionResult from './SectionResult';
 import SidebarHeader from '../SidebarHeader';
 
-export const styles = {
+const useStyles = makeStyles({
   sectionsRoot: {
     padding: 16,
   },
@@ -17,16 +17,16 @@ export const styles = {
   divider: {
     marginTop: 5,
   },
-};
+});
 
-function SectionSelection({
+export default function SectionSelection({
   currentCourseName,
   sections,
   scheduledSections,
   addSection,
   back,
-  classes,
 }) {
+  const classes = useStyles();
   return (
     <div className={classes.sectionsRoot}>
       <SidebarHeader title={currentCourseName} back={back} />
@@ -56,12 +56,8 @@ SectionSelection.propTypes = {
   scheduledSections: PropTypes.arrayOf(PropTypes.object),
   addSection: PropTypes.func.isRequired,
   back: PropTypes.func.isRequired,
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
 };
 
 SectionSelection.defaultProps = {
   scheduledSections: [],
 };
-
-export { SectionSelection as UnstyledSectionSelection };
-export default withStyles(styles)(SectionSelection);

--- a/src/components/sidebar/common/SectionSelection.test.js
+++ b/src/components/sidebar/common/SectionSelection.test.js
@@ -1,6 +1,7 @@
-import { wrapperCreator } from 'util/testing';
+import React from 'react';
+import { shallow } from 'enzyme';
 import * as timeUtils from 'util/time';
-import { UnstyledSectionSelection, styles } from './SectionSelection';
+import SectionSelection from './SectionSelection';
 import SectionResult from './SectionResult';
 
 describe('SectionSelection', () => {
@@ -33,7 +34,6 @@ describe('SectionSelection', () => {
     }],
     instructors: ['Jason Hartline'],
   }];
-  const getComponent = wrapperCreator(UnstyledSectionSelection, defaultProps, styles);
 
   beforeEach(() => {
     timeUtils.getFormattedClassSchedule = jest.fn();
@@ -41,13 +41,18 @@ describe('SectionSelection', () => {
   });
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<SectionSelection {...defaultProps} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('disables sections that are already scheduled', () => {
-    const wrapper = getComponent({ scheduledSections: scheduledSectionsTestData });
+    const wrapper = shallow(
+      <SectionSelection
+        {...defaultProps}
+        scheduledSections={scheduledSectionsTestData}
+      />,
+    );
     expect(
       wrapper
         .findWhere(

--- a/src/components/sidebar/common/__snapshots__/AssociatedClassesSelection.test.js.snap
+++ b/src/components/sidebar/common/__snapshots__/AssociatedClassesSelection.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`AssociatedClassesSelection renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-sectionsRoot-1"
 >
-  <ForwardRef(WithStyles)
+  <SidebarHeader
     back={[Function]}
     title="Introduction to Something-21"
   />

--- a/src/components/sidebar/common/__snapshots__/SectionSelection.test.js.snap
+++ b/src/components/sidebar/common/__snapshots__/SectionSelection.test.js.snap
@@ -2,9 +2,9 @@
 
 exports[`SectionSelection renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-sectionsRoot-1"
 >
-  <ForwardRef(WithStyles)
+  <SidebarHeader
     back={[Function]}
     title="EECS 101-0"
   />

--- a/src/components/sidebar/search/SearchBox.js
+++ b/src/components/sidebar/search/SearchBox.js
@@ -1,20 +1,20 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { debounce } from 'debounce';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { TextField } from '@material-ui/core';
 import { currentSearchInputSelector } from 'selectors';
 import { fetchSearchResultsRequest, clearSearchResults, updateSearchInput } from 'actions';
 import useSelector from 'util/use-selector';
 
-export const styles = {
+const useStyles = makeStyles({
   container: {
     margin: 15,
   },
-};
+});
 
-function SearchBox({ classes }) {
+export default function SearchBox() {
+  const classes = useStyles();
   const currentSearchInput = useSelector(currentSearchInputSelector);
   const dispatch = useDispatch();
 
@@ -40,11 +40,3 @@ function SearchBox({ classes }) {
     </div>
   );
 }
-
-export { SearchBox as UnstyledSearchBox };
-
-export default withStyles(styles)(SearchBox);
-
-SearchBox.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};

--- a/src/components/sidebar/search/SearchBox.test.js
+++ b/src/components/sidebar/search/SearchBox.test.js
@@ -1,7 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { TextField } from '@material-ui/core';
 import { fetchSearchResultsRequest } from 'actions';
-import { wrapperCreator, mockUseSelector, mockUseDispatch } from 'util/testing';
-import { UnstyledSearchBox, styles } from './SearchBox';
+import { mockUseSelector, mockUseDispatch } from 'util/testing';
+import SearchBox from './SearchBox';
 
 describe('SearchBox', () => {
   function makeEventObject(value) {
@@ -15,7 +17,6 @@ describe('SearchBox', () => {
     updateSearchInput: () => {},
     currentSearchInput: '',
   };
-  const getWrapper = wrapperCreator(UnstyledSearchBox, defaultProps, styles);
 
   let dispatchMock;
   beforeEach(() => {
@@ -25,13 +26,13 @@ describe('SearchBox', () => {
 
 
   it('renders correctly', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<SearchBox {...defaultProps} />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('renders text typed into the search box', () => {
-    const wrapper = getWrapper();
+    const wrapper = shallow(<SearchBox {...defaultProps} />);
 
     const eventObject = makeEventObject(testSearchInput);
     wrapper.find(TextField).first().simulate('change', eventObject);
@@ -42,7 +43,12 @@ describe('SearchBox', () => {
   it('doesn\'t call api unless it has been 300ms since last keystroke', (completed) => {
     const handleSearchInputMock = jest.fn();
 
-    const wrapper = getWrapper({ handleSearchInput: handleSearchInputMock });
+    const wrapper = shallow(
+      <SearchBox
+        {...defaultProps}
+        handleSearchInput={handleSearchInputMock}
+      />,
+    );
 
     expect(dispatchMock).not.toBeCalled();
 
@@ -61,7 +67,12 @@ describe('SearchBox', () => {
 
   it('doesn\'t call api through handler if search string <= 2 chars long', () => {
     const handleSearchInputMock = jest.fn();
-    const wrapper = getWrapper({ handleSearchInput: handleSearchInputMock });
+    const wrapper = shallow(
+      <SearchBox
+        {...defaultProps}
+        handleSearchInput={handleSearchInputMock}
+      />,
+    );
 
     const shortTestSearchInput = 'EE';
     const eventObject = makeEventObject(shortTestSearchInput);

--- a/src/components/sidebar/search/SearchResults.js
+++ b/src/components/sidebar/search/SearchResults.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
-import { withStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/styles';
 import { List, ListItem, ListItemText, CircularProgress, Typography } from '@material-ui/core';
 import useSelector from 'util/use-selector';
 import { searchResultsSelector, searchIsFetchingSelector, currentSearchInputSelector } from 'selectors';
 import { fetchSectionsForSearchRequest, setCurrentCourseName } from 'actions';
 
-export const styles = {
+const useStyles = makeStyles({
   loadingContainer: {
     margin: 15,
     display: 'flex',
@@ -17,9 +16,10 @@ export const styles = {
     display: 'flex',
     justifyContent: 'center',
   },
-};
+});
 
-function SearchResults({ classes }) {
+export default function SearchResults() {
+  const classes = useStyles();
   const searchResults = useSelector(searchResultsSelector);
   const isFetching = useSelector(searchIsFetchingSelector);
   const currentSearchInput = useSelector(currentSearchInputSelector);
@@ -65,10 +65,3 @@ function SearchResults({ classes }) {
     </div>
   );
 }
-
-SearchResults.propTypes = {
-  classes: PropTypes.objectOf(PropTypes.string).isRequired,
-};
-
-export { SearchResults as UnstyledSearchResults };
-export default withStyles(styles)(SearchResults);

--- a/src/components/sidebar/search/SearchResults.test.js
+++ b/src/components/sidebar/search/SearchResults.test.js
@@ -1,7 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { ListItem } from '@material-ui/core';
-import { wrapperCreator, mockUseSelector, mockUseDispatch } from 'util/testing';
+import { mockUseSelector, mockUseDispatch } from 'util/testing';
 import { fetchSectionsForSearchRequest, setCurrentCourseName } from 'actions';
-import { UnstyledSearchResults, styles } from './SearchResults';
+import SearchResults from './SearchResults';
 
 describe('SearchResults', () => {
   const testResults = [{
@@ -19,42 +21,40 @@ describe('SearchResults', () => {
   }];
   const testSearchInput = 'EECS';
 
-  const getComponent = wrapperCreator(UnstyledSearchResults, undefined, styles);
-
   beforeEach(() => {
     mockUseSelector(testResults, false, testSearchInput);
   });
 
   it('renders correctly', () => {
-    const wrapper = getComponent();
+    const wrapper = shallow(<SearchResults />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('renders loading correctly', () => {
     mockUseSelector(testResults, true, testSearchInput);
-    const wrapper = getComponent();
+    const wrapper = shallow(<SearchResults />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it("renders 'keep typing' correctly", () => {
     mockUseSelector(testResults, false, 'EE');
-    const wrapper = getComponent();
+    const wrapper = shallow(<SearchResults />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it("renders 'no results' correctly", () => {
     mockUseSelector([], false, 'ABCD');
-    const wrapper = getComponent();
+    const wrapper = shallow(<SearchResults />);
 
     expect(wrapper.get(0)).toMatchSnapshot();
   });
 
   it('handleCourseClick gets called correctly', () => {
     const dispatchMock = mockUseDispatch();
-    const wrapper = getComponent();
+    const wrapper = shallow(<SearchResults />);
 
     wrapper.find(ListItem).first().simulate('click');
 

--- a/src/components/sidebar/search/__snapshots__/Search.test.js.snap
+++ b/src/components/sidebar/search/__snapshots__/Search.test.js.snap
@@ -9,8 +9,8 @@ exports[`Search renders associatedClassesSelection view correctly 1`] = `
 exports[`Search renders correctly 1`] = `
 <div>
   <React.Fragment>
-    <ForwardRef(WithStyles) />
-    <ForwardRef(WithStyles) />
+    <SearchBox />
+    <SearchResults />
   </React.Fragment>
 </div>
 `;

--- a/src/components/sidebar/search/__snapshots__/SearchAssociatedClassesSelectionContainer.test.js.snap
+++ b/src/components/sidebar/search/__snapshots__/SearchAssociatedClassesSelectionContainer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchAssociatedClassesSelectionContainer renders 1`] = `
-<ForwardRef(WithStyles)
+<AssociatedClassesSelection
   addSectionWithAssociatedClass={[Function]}
   associatedClassHover={[Function]}
   associatedClassHoverOff={[Function]}

--- a/src/components/sidebar/search/__snapshots__/SearchBox.test.js.snap
+++ b/src/components/sidebar/search/__snapshots__/SearchBox.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SearchBox renders correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-container-1"
 >
   <ForwardRef(WithStyles)
     fullWidth={true}
@@ -16,7 +16,7 @@ exports[`SearchBox renders correctly 1`] = `
 
 exports[`SearchBox renders text typed into the search box 1`] = `
 <div
-  className=""
+  className="makeStyles-container-1"
 >
   <ForwardRef(WithStyles)
     fullWidth={true}

--- a/src/components/sidebar/search/__snapshots__/SearchResults.test.js.snap
+++ b/src/components/sidebar/search/__snapshots__/SearchResults.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SearchResults renders 'keep typing' correctly 1`] = `
 <div>
   <ForwardRef(WithStyles)
-    className=""
+    className="makeStyles-inputHint-2"
   >
      Keep typing!
   </ForwardRef(WithStyles)>
@@ -30,7 +30,7 @@ exports[`SearchResults renders 'keep typing' correctly 1`] = `
 
 exports[`SearchResults renders 'no results' correctly 1`] = `
 <ForwardRef(WithStyles)
-  className=""
+  className="makeStyles-inputHint-2"
 >
   No results
 </ForwardRef(WithStyles)>
@@ -61,7 +61,7 @@ exports[`SearchResults renders correctly 1`] = `
 
 exports[`SearchResults renders loading correctly 1`] = `
 <div
-  className=""
+  className="makeStyles-loadingContainer-1"
 >
   <ForwardRef(WithStyles) />
 </div>

--- a/src/components/sidebar/search/__snapshots__/SearchSectionSelectionContainer.test.js.snap
+++ b/src/components/sidebar/search/__snapshots__/SearchSectionSelectionContainer.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SearchSectionSelectionContainer renders correctly 1`] = `
-<ForwardRef(WithStyles)
+<SectionSelection
   addSection={[Function]}
   back={[Function]}
   currentCourseName="course name"

--- a/src/util/testing.js
+++ b/src/util/testing.js
@@ -6,23 +6,9 @@ import * as useSelector from './use-selector';
 
 jest.mock('./use-selector');
 
-// Helper function used to inject mock styles into a styled component for testing
-export function mockStyles(style) {
-  const mockedClasses = {};
-
-  Object.keys(style).forEach((property) => {
-    mockedClasses[property] = '';
-  });
-
-  return mockedClasses;
-}
-
 // Helper function that returns a function which creates enzyme wrappers with default props
-export function wrapperCreator(Component, defaultProps = {}, styles = undefined) {
+export function wrapperCreator(Component, defaultProps = {}) {
   let classes;
-  if (styles) {
-    classes = mockStyles(styles);
-  }
   return props => shallow(<Component classes={classes} {...defaultProps} {...props} />);
 }
 

--- a/src/util/testing.test.js
+++ b/src/util/testing.test.js
@@ -1,22 +1,7 @@
 import React from 'react';
-import { mockStyles, wrapperCreator } from './testing';
+import { wrapperCreator } from './testing';
 
 describe('Testing Utils', () => {
-  describe('mockStyles', () => {
-    it('returns a object with each style property as empty strings', () => {
-      const style = {
-        icon: {
-          color: 'white',
-        },
-        title: {
-          marginBotton: 2,
-        },
-      };
-
-      expect(mockStyles(style)).toEqual({ icon: '', title: '' });
-    });
-  });
-
   describe('wrapperCreator', () => {
     it('creates a wrapper creator function', () => {
       const TestComponent = () => <div />;


### PR DESCRIPTION
With the migration to Material-UI 4, `withStyles` now uses `React.forwardRef`, which makes our snapshot testing less helpful as everything is wrapped in `<ForwardRef>`s. In the interest of slowly converting to using the Hooks API, this PR converts all usage of withStyles into makeStyle hooks instead. This also means that all snapshots were updated.

This PR also converts `AssociatedClass` and `ClassModal` from class to function components, as well as modifies the contributing documentation now that we do not use the `withStyles` HOC pattern while testing. Some small mistakes that weren't caught in tests were also fixed. 