### PR TITLE
Make data structure prop types to be reused

### DIFF
--- a/src/components/calendar/AssociatedClass.js
+++ b/src/components/calendar/AssociatedClass.js
@@ -2,6 +2,7 @@ import React, { Fragment, useState } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import { getFormattedEventTime, getDurationInHours } from 'util/time';
+import { sectionPropType, associatedClassPropType } from 'util/prop-types';
 import Section from 'components/common/Section';
 import ClassModal from './ClassModal';
 
@@ -74,8 +75,8 @@ export default function AssociatedClass({ associatedClass, section, isPreview })
 }
 
 AssociatedClass.propTypes = {
-  associatedClass: PropTypes.objectOf(PropTypes.any).isRequired, // TODO
-  section: PropTypes.objectOf(PropTypes.any).isRequired,
+  associatedClass: PropTypes.shape(associatedClassPropType).isRequired,
+  section: PropTypes.shape(sectionPropType).isRequired,
   isPreview: PropTypes.bool,
 };
 

--- a/src/components/calendar/AssociatedClass.test.js
+++ b/src/components/calendar/AssociatedClass.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import * as timeUtils from 'util/time';
 import Section from 'components/common/Section';
+import { testSchedule, testSection } from 'util/testing';
 import ClassModal from './ClassModal';
 import AssociatedClass, { styles, MAX_WIDTH_PERCENT } from './AssociatedClass';
 
@@ -9,17 +10,8 @@ jest.mock('util/time');
 
 describe('dynamic styles', () => {
   const dow = 'Mo';
-  const event = {
-    dow,
-    start: {
-      hour: 10,
-      minute: 30,
-    },
-    end: {
-      hour: 12,
-      minute: 0,
-    },
-  };
+  const event = { ...testSchedule, dow };
+
   const hour = 10;
   const color = 'some color';
   const associatedClass = { event, color, column: 0, columnWidth: 1 };
@@ -56,23 +48,24 @@ describe('dynamic styles', () => {
 
 describe('AssociatedClass', () => {
   const dow = 'Mo';
-  const event = {
-    dow,
-    start: {
-      hour: 10,
-      minute: 30,
-    },
-    end: {
-      hour: 12,
-      minute: 0,
+  const event = { ...testSchedule, dow };
+  const color = 'some color';
+  const associatedClass = {
+    event,
+    color,
+    column: 0,
+    columnWidth: 1,
+    type: 'LAB',
+    schedule: {
+      ...event,
+      dow: ['Mo'],
+      location: 'Somewhere',
     },
   };
-  const color = 'some color';
-  const associatedClass = { event, color, column: 0, columnWidth: 1 };
 
   const defaultProps = {
     associatedClass,
-    section: { subjectId: 'EECS', courseId: '111-0' },
+    section: testSection,
     isPreview: false,
   };
 

--- a/src/components/calendar/CalendarSection.js
+++ b/src/components/calendar/CalendarSection.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
+import { sectionPropType } from 'util/prop-types';
 import { getFormattedEventTime, getDurationInHours } from 'util/time';
 import Section from 'components/common/Section';
 import ClassModal from './ClassModal';
@@ -79,7 +80,7 @@ export default function CalendarSection({ section, isPreview }) {
 }
 
 CalendarSection.propTypes = {
-  section: PropTypes.objectOf(PropTypes.any).isRequired, // TODO
+  section: PropTypes.shape(sectionPropType).isRequired,
   isPreview: PropTypes.bool,
 };
 

--- a/src/components/calendar/CalendarSection.test.js
+++ b/src/components/calendar/CalendarSection.test.js
@@ -1,27 +1,16 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Section from 'components/common/Section';
+import { testSchedule, testSection } from 'util/testing';
 import ClassModal from './ClassModal';
 import CalendarSection, { styles, MAX_WIDTH_PERCENT } from './CalendarSection';
 
 describe('CalendarSection', () => {
   const dow = 'Mo';
-  const event = {
-    dow,
-    start: {
-      hour: 10,
-      minute: 30,
-    },
-    end: {
-      hour: 12,
-      minute: 0,
-    },
-  };
-  const name = 'Seminar';
+  const event = { ...testSchedule, dow };
   const topic = 'Propaganda';
-
-  const testSection = { id: '12345', course: '101-1', event, name, topic: '' };
-  const testSectionWithTopic = { id: '12345', course: '101-1', event, name, topic };
+  const testSectionWithEvent = { ...testSection, event, topic: '' };
+  const testSectionWithTopic = { ...testSectionWithEvent, topic };
 
   describe('dynamic styles', () => {
     const hour = 10;
@@ -67,7 +56,7 @@ describe('CalendarSection', () => {
 
   it('renders correctly', () => {
     const wrapper = shallow(
-      <CalendarSection section={testSection} />,
+      <CalendarSection section={testSectionWithEvent} />,
     );
 
     expect(wrapper.get(0)).toMatchSnapshot();
@@ -75,7 +64,7 @@ describe('CalendarSection', () => {
 
   it('renders modal correctly', () => {
     const wrapper = shallow(
-      <CalendarSection section={testSection} />,
+      <CalendarSection section={testSectionWithEvent} />,
     );
 
     wrapper.find(Section).simulate('click');
@@ -85,7 +74,7 @@ describe('CalendarSection', () => {
 
   it('does nothing as a preview section when clicked', () => {
     const wrapper = shallow(
-      <CalendarSection section={testSection} isPreview />,
+      <CalendarSection section={testSectionWithEvent} isPreview />,
     );
 
     wrapper.find(Section).simulate('click');

--- a/src/components/calendar/ClassModal.js
+++ b/src/components/calendar/ClassModal.js
@@ -4,6 +4,7 @@ import { useDispatch } from 'react-redux';
 import { useSnackbar } from 'notistack';
 import { makeStyles } from '@material-ui/styles';
 import { Dialog, DialogActions, DialogTitle, DialogContent, DialogContentText, Button } from '@material-ui/core';
+import { sectionPropType, associatedClassPropType } from 'util/prop-types';
 import { getFormattedClassSchedule } from 'util/time';
 import { removeSection } from 'actions';
 
@@ -93,8 +94,8 @@ export default function ClassModal({ showDialog, toggleDialog, section, associat
 }
 
 ClassModal.propTypes = {
-  section: PropTypes.objectOf(PropTypes.any).isRequired,
-  associatedClass: PropTypes.objectOf(PropTypes.any),
+  associatedClass: PropTypes.shape(associatedClassPropType),
+  section: PropTypes.shape(sectionPropType).isRequired,
   showDialog: PropTypes.bool.isRequired,
   toggleDialog: PropTypes.func.isRequired,
 };

--- a/src/components/calendar/ClassModal.test.js
+++ b/src/components/calendar/ClassModal.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import * as notistack from 'notistack';
 import { Button, DialogTitle } from '@material-ui/core';
-import { mockUseDispatch } from 'util/testing';
+import { mockUseDispatch, testSection } from 'util/testing';
 import { removeSection } from 'actions';
 import ClassModal from './ClassModal';
 
@@ -10,27 +10,7 @@ jest.mock('notistack');
 jest.mock('react-redux');
 
 describe('ClassModal', () => {
-  const section = {
-    id: '198732',
-    name: 'Introduction to Something',
-    sectionNumber: 20,
-    topic: 'Section topic...',
-    schedules: [{
-      location: 'somewhere',
-      dow: ['Mo'],
-      start: {
-        hour: 10,
-        minute: 30,
-      },
-      end: {
-        hour: 12,
-        minute: 0,
-      },
-    }],
-    instructors: ['A prof'],
-    color: '#58B947',
-    descriptions: [{ name: '', value: '' }],
-  };
+  const section = { ...testSection, color: '#58B947' };
   const defaultProps = {
     section,
     showDialog: true,
@@ -62,6 +42,7 @@ describe('ClassModal', () => {
           hour: 12,
           minute: 0,
         },
+        location: 'somewhere',
       },
     };
     const wrapper = shallow(

--- a/src/components/calendar/HourCell.test.js
+++ b/src/components/calendar/HourCell.test.js
@@ -9,10 +9,49 @@ import AssociatedClass from './AssociatedClass';
 jest.mock('selectors');
 
 describe('HourCell', () => {
-  const testSections = [{ id: '12345' }];
-  const allSections = [{ id: '12345' }];
+  const dow = ['Mo'];
+  const schedule = {
+    dow,
+    start: {
+      hour: 10,
+      minute: 30,
+    },
+    end: {
+      hour: 12,
+      minute: 0,
+    },
+    location: '',
+  };
+  const name = 'Seminar';
+  const description = { name: '', value: '' };
+  const testAssociatedClass = {
+    sectionId: '12345',
+    schedule: {
+      ...schedule,
+      dow: ['Tu'],
+    },
+    type: 'DIS',
+  };
+  const testSection = {
+    id: '12345',
+    termId: '111111',
+    schoolId: 'MEAS',
+    subjectId: 'COMP_SCI',
+    courseId: '101-1',
+    name,
+    sectionNumber: '1',
+    topic: '',
+    descriptions: [description],
+    instructors: [''],
+    schedules: [schedule],
+  };
+  const testSections = [testSection];
+  const allSections = [testSection];
   const allSectionPreviews = [];
-  const associatedClasses = [{ sectionId: '12345', event: {} }];
+  const associatedClasses = [{
+    ...testAssociatedClass,
+    event: {},
+  }];
 
   let useSelectorMock;
 
@@ -86,7 +125,7 @@ describe('HourCell', () => {
   });
 
   it('renders section previews', () => {
-    const sectionPreview = { id: '12345' };
+    const sectionPreview = testSection;
 
     mockUseSelector(
       testSections, associatedClasses, sectionPreview, undefined, allSections, [sectionPreview],
@@ -103,10 +142,15 @@ describe('HourCell', () => {
   });
 
   it('renders associated class previews', () => {
-    const associatedClassPreview = { type: 'LAB' };
+    const associatedClassPreview = testAssociatedClass;
 
     mockUseSelector(
-      testSections, associatedClasses, undefined, associatedClassPreview, allSections, [{ id: '12345' }],
+      testSections,
+      associatedClasses,
+      undefined,
+      associatedClassPreview,
+      allSections,
+      [testSection],
     );
 
     const wrapper = shallow(

--- a/src/components/calendar/__snapshots__/AssociatedClass.test.js.snap
+++ b/src/components/calendar/__snapshots__/AssociatedClass.test.js.snap
@@ -13,8 +13,8 @@ exports[`AssociatedClass renders correctly 1`] = `
     }
     leftHeaderContent="left hand header content"
     onClick={[Function]}
-    rightHeaderContent="EECS 111-0"
-    sectionName="undefined - undefined"
+    rightHeaderContent="COMP_SCI 101-1"
+    sectionName="LAB - Introduction to Something"
   />
   <ClassModal
     associatedClass={
@@ -28,17 +28,64 @@ exports[`AssociatedClass renders correctly 1`] = `
             "hour": 12,
             "minute": 0,
           },
+          "location": "Somewhere",
           "start": Object {
             "hour": 10,
             "minute": 30,
           },
         },
+        "schedule": Object {
+          "dow": Array [
+            "Mo",
+          ],
+          "end": Object {
+            "hour": 12,
+            "minute": 0,
+          },
+          "location": "Somewhere",
+          "start": Object {
+            "hour": 10,
+            "minute": 30,
+          },
+        },
+        "type": "LAB",
       }
     }
     section={
       Object {
-        "courseId": "111-0",
-        "subjectId": "EECS",
+        "courseId": "101-1",
+        "descriptions": Array [
+          Object {
+            "name": "",
+            "value": "",
+          },
+        ],
+        "id": "12345",
+        "instructors": Array [
+          "",
+        ],
+        "name": "Introduction to Something",
+        "schedules": Array [
+          Object {
+            "dow": Array [
+              "Mo",
+            ],
+            "end": Object {
+              "hour": 12,
+              "minute": 0,
+            },
+            "location": "Somewhere",
+            "start": Object {
+              "hour": 10,
+              "minute": 30,
+            },
+          },
+        ],
+        "schoolId": "MEAS",
+        "sectionNumber": "1",
+        "subjectId": "COMP_SCI",
+        "termId": "111111",
+        "topic": "Section topic...",
       }
     }
     showDialog={false}

--- a/src/components/calendar/__snapshots__/CalendarSection.test.js.snap
+++ b/src/components/calendar/__snapshots__/CalendarSection.test.js.snap
@@ -13,27 +13,57 @@ exports[`CalendarSection renders correctly 1`] = `
     }
     leftHeaderContent="10:30 - 12:00"
     onClick={[Function]}
-    rightHeaderContent="undefined undefined"
-    sectionName="Seminar"
+    rightHeaderContent="COMP_SCI 101-1"
+    sectionName="Introduction to Something"
   />
   <ClassModal
     associatedClass={null}
     section={
       Object {
-        "course": "101-1",
+        "courseId": "101-1",
+        "descriptions": Array [
+          Object {
+            "name": "",
+            "value": "",
+          },
+        ],
         "event": Object {
           "dow": "Mo",
           "end": Object {
             "hour": 12,
             "minute": 0,
           },
+          "location": "Somewhere",
           "start": Object {
             "hour": 10,
             "minute": 30,
           },
         },
         "id": "12345",
-        "name": "Seminar",
+        "instructors": Array [
+          "",
+        ],
+        "name": "Introduction to Something",
+        "schedules": Array [
+          Object {
+            "dow": Array [
+              "Mo",
+            ],
+            "end": Object {
+              "hour": 12,
+              "minute": 0,
+            },
+            "location": "Somewhere",
+            "start": Object {
+              "hour": 10,
+              "minute": 30,
+            },
+          },
+        ],
+        "schoolId": "MEAS",
+        "sectionNumber": "1",
+        "subjectId": "COMP_SCI",
+        "termId": "111111",
         "topic": "",
       }
     }

--- a/src/components/calendar/__snapshots__/ClassModal.test.js.snap
+++ b/src/components/calendar/__snapshots__/ClassModal.test.js.snap
@@ -20,7 +20,7 @@ exports[`ClassModal renders correctly 1`] = `
       <ForwardRef(WithStyles)
         variant="subtitle1"
       >
-        undefined undefined Section 20
+        COMP_SCI 101-1 Section 1
       </ForwardRef(WithStyles)>
       <div>
         <ForwardRef(WithStyles)
@@ -29,13 +29,13 @@ exports[`ClassModal renders correctly 1`] = `
           Mo 10:30 AM - 12:00 PM
         </ForwardRef(WithStyles)>
         <ForwardRef(WithStyles)>
-          somewhere
+          Somewhere
         </ForwardRef(WithStyles)>
       </div>
       <ForwardRef(WithStyles)
         className="makeStyles-noBorder-2"
       >
-        A prof
+        
       </ForwardRef(WithStyles)>
       <br />
       <div>
@@ -73,6 +73,8 @@ exports[`ClassModal renders correctly for associated class 1`] = `
   >
     Mo 10:30 AM - 12:00 PM
   </ForwardRef(WithStyles)>
-  <ForwardRef(WithStyles) />
+  <ForwardRef(WithStyles)>
+    somewhere
+  </ForwardRef(WithStyles)>
 </div>
 `;

--- a/src/components/calendar/__snapshots__/HourCell.test.js.snap
+++ b/src/components/calendar/__snapshots__/HourCell.test.js.snap
@@ -8,7 +8,39 @@ exports[`HourCell renders correctly 1`] = `
     isPreview={false}
     section={
       Object {
+        "courseId": "101-1",
+        "descriptions": Array [
+          Object {
+            "name": "",
+            "value": "",
+          },
+        ],
         "id": "12345",
+        "instructors": Array [
+          "",
+        ],
+        "name": "Seminar",
+        "schedules": Array [
+          Object {
+            "dow": Array [
+              "Mo",
+            ],
+            "end": Object {
+              "hour": 12,
+              "minute": 0,
+            },
+            "location": "",
+            "start": Object {
+              "hour": 10,
+              "minute": 30,
+            },
+          },
+        ],
+        "schoolId": "MEAS",
+        "sectionNumber": "1",
+        "subjectId": "COMP_SCI",
+        "termId": "111111",
+        "topic": "",
       }
     }
   />
@@ -16,13 +48,60 @@ exports[`HourCell renders correctly 1`] = `
     associatedClass={
       Object {
         "event": Object {},
+        "schedule": Object {
+          "dow": Array [
+            "Tu",
+          ],
+          "end": Object {
+            "hour": 12,
+            "minute": 0,
+          },
+          "location": "",
+          "start": Object {
+            "hour": 10,
+            "minute": 30,
+          },
+        },
         "sectionId": "12345",
+        "type": "DIS",
       }
     }
     isPreview={false}
     section={
       Object {
+        "courseId": "101-1",
+        "descriptions": Array [
+          Object {
+            "name": "",
+            "value": "",
+          },
+        ],
         "id": "12345",
+        "instructors": Array [
+          "",
+        ],
+        "name": "Seminar",
+        "schedules": Array [
+          Object {
+            "dow": Array [
+              "Mo",
+            ],
+            "end": Object {
+              "hour": 12,
+              "minute": 0,
+            },
+            "location": "",
+            "start": Object {
+              "hour": 10,
+              "minute": 30,
+            },
+          },
+        ],
+        "schoolId": "MEAS",
+        "sectionNumber": "1",
+        "subjectId": "COMP_SCI",
+        "termId": "111111",
+        "topic": "",
       }
     }
   />

--- a/src/components/sidebar/cart/Cart.test.js
+++ b/src/components/sidebar/cart/Cart.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { mockUseSelector } from 'util/testing';
+import { mockUseSelector, testSection } from 'util/testing';
 import { Button } from '@material-ui/core';
 import Cart from './Cart';
 import CartDialog from './CartDialog';
@@ -17,7 +17,7 @@ describe('Cart', () => {
   });
 
   it('renders correctly with one section', () => {
-    mockUseSelector([{ id: '12345' }]);
+    mockUseSelector([testSection]);
 
     const wrapper = shallow(<Cart />);
 
@@ -25,7 +25,7 @@ describe('Cart', () => {
   });
 
   it('renders correctly with multiple sections with the same id', () => {
-    mockUseSelector([{ id: '123' }, { id: '123' }]);
+    mockUseSelector([testSection, testSection]);
 
     const wrapper = shallow(<Cart />);
 
@@ -33,7 +33,7 @@ describe('Cart', () => {
   });
 
   it('opens the modal when clicked', () => {
-    mockUseSelector([{ id: '123' }, { id: '123' }]);
+    mockUseSelector([testSection, testSection]);
 
     const wrapper = shallow(<Cart />);
     wrapper.find(Button).first().simulate('click');

--- a/src/components/sidebar/cart/CartSection.js
+++ b/src/components/sidebar/cart/CartSection.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import { getFormattedClassSchedule } from 'util/time';
+import { sectionPropType } from 'util/prop-types';
 import Section from 'components/common/Section';
 import ClassModal from 'components/calendar/ClassModal';
 
@@ -66,5 +67,5 @@ export default function CartSection({ section }) {
 }
 
 CartSection.propTypes = {
-  section: PropTypes.objectOf(PropTypes.any).isRequired, // TODO
+  section: PropTypes.shape(sectionPropType).isRequired,
 };

--- a/src/components/sidebar/cart/CartSection.test.js
+++ b/src/components/sidebar/cart/CartSection.test.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import * as timeUtils from 'util/time';
+import { testSchedule, testSection } from 'util/testing';
 import Section from 'components/common/Section';
 import ClassModal from 'components/calendar/ClassModal';
 import CartSection, { styles } from './CartSection';
 
 describe('CartSection', () => {
+  const testSectionWithMultipleSchedules = {
+    ...testSection,
+    schedules: [testSchedule, testSchedule],
+  };
+
   beforeEach(() => {
     timeUtils.getFormattedClassSchedule = jest.fn();
     timeUtils.getFormattedClassSchedule.mockReturnValue('schedules');
@@ -20,7 +26,6 @@ describe('CartSection', () => {
   });
 
   it('renders correctly', () => {
-    const testSection = { schedules: [{}], subjectId: 'EECS', courseId: '111-0' };
     const wrapper = shallow(
       <CartSection section={testSection} />,
     );
@@ -29,16 +34,14 @@ describe('CartSection', () => {
   });
 
   it('formats left header content correctly when multiple schedules present', () => {
-    const testSection = { schedules: [{}, {}], subjectId: 'EECS', courseId: '111-0' };
     const wrapper = shallow(
-      <CartSection section={testSection} />,
+      <CartSection section={testSectionWithMultipleSchedules} />,
     );
 
     expect(wrapper.find(Section).prop('leftHeaderContent')).toBe('schedules, schedules');
   });
 
   it('opens modal on click', () => {
-    const testSection = { schedules: [{}], subjectId: 'EECS', courseId: '111-0' };
     const wrapper = shallow(
       <CartSection section={testSection} />,
     );

--- a/src/components/sidebar/cart/__snapshots__/Cart.test.js.snap
+++ b/src/components/sidebar/cart/__snapshots__/Cart.test.js.snap
@@ -43,7 +43,39 @@ exports[`Cart renders correctly with multiple sections with the same id 1`] = `
   <CartSection
     section={
       Object {
-        "id": "123",
+        "courseId": "101-1",
+        "descriptions": Array [
+          Object {
+            "name": "",
+            "value": "",
+          },
+        ],
+        "id": "12345",
+        "instructors": Array [
+          "",
+        ],
+        "name": "Introduction to Something",
+        "schedules": Array [
+          Object {
+            "dow": Array [
+              "Mo",
+            ],
+            "end": Object {
+              "hour": 12,
+              "minute": 0,
+            },
+            "location": "Somewhere",
+            "start": Object {
+              "hour": 10,
+              "minute": 30,
+            },
+          },
+        ],
+        "schoolId": "MEAS",
+        "sectionNumber": "1",
+        "subjectId": "COMP_SCI",
+        "termId": "111111",
+        "topic": "Section topic...",
       }
     }
   />
@@ -74,7 +106,39 @@ exports[`Cart renders correctly with one section 1`] = `
   <CartSection
     section={
       Object {
+        "courseId": "101-1",
+        "descriptions": Array [
+          Object {
+            "name": "",
+            "value": "",
+          },
+        ],
         "id": "12345",
+        "instructors": Array [
+          "",
+        ],
+        "name": "Introduction to Something",
+        "schedules": Array [
+          Object {
+            "dow": Array [
+              "Mo",
+            ],
+            "end": Object {
+              "hour": 12,
+              "minute": 0,
+            },
+            "location": "Somewhere",
+            "start": Object {
+              "hour": 10,
+              "minute": 30,
+            },
+          },
+        ],
+        "schoolId": "MEAS",
+        "sectionNumber": "1",
+        "subjectId": "COMP_SCI",
+        "termId": "111111",
+        "topic": "Section topic...",
       }
     }
   />

--- a/src/components/sidebar/cart/__snapshots__/CartSection.test.js.snap
+++ b/src/components/sidebar/cart/__snapshots__/CartSection.test.js.snap
@@ -13,18 +13,46 @@ exports[`CartSection renders correctly 1`] = `
     }
     leftHeaderContent="schedules"
     onClick={[Function]}
-    rightHeaderContent="EECS 111-0"
-    sectionName=""
+    rightHeaderContent="COMP_SCI 101-1"
+    sectionName="Introduction to Something"
   />
   <ClassModal
     associatedClass={null}
     section={
       Object {
-        "courseId": "111-0",
-        "schedules": Array [
-          Object {},
+        "courseId": "101-1",
+        "descriptions": Array [
+          Object {
+            "name": "",
+            "value": "",
+          },
         ],
-        "subjectId": "EECS",
+        "id": "12345",
+        "instructors": Array [
+          "",
+        ],
+        "name": "Introduction to Something",
+        "schedules": Array [
+          Object {
+            "dow": Array [
+              "Mo",
+            ],
+            "end": Object {
+              "hour": 12,
+              "minute": 0,
+            },
+            "location": "Somewhere",
+            "start": Object {
+              "hour": 10,
+              "minute": 30,
+            },
+          },
+        ],
+        "schoolId": "MEAS",
+        "sectionNumber": "1",
+        "subjectId": "COMP_SCI",
+        "termId": "111111",
+        "topic": "Section topic...",
       }
     }
     showDialog={false}

--- a/src/components/sidebar/common/SectionResult.js
+++ b/src/components/sidebar/common/SectionResult.js
@@ -5,6 +5,7 @@ import { makeStyles } from '@material-ui/styles';
 import { ListItem, ListItemText, Typography } from '@material-ui/core';
 import { sectionHover, sectionHoverOff } from 'actions';
 import { getFormattedClassSchedule, isUnscheduled } from 'util/time';
+import { sectionPropType } from 'util/prop-types';
 import { useSnackbar } from 'notistack';
 
 const useStyles = makeStyles({
@@ -66,7 +67,7 @@ export default function SectionResult({ addSection, section, disabled }) {
 
 SectionResult.propTypes = {
   addSection: PropTypes.func.isRequired,
-  section: PropTypes.objectOf(PropTypes.any).isRequired, // TODO
+  section: PropTypes.shape(sectionPropType).isRequired,
   disabled: PropTypes.bool,
 };
 

--- a/src/components/sidebar/common/SectionResult.test.js
+++ b/src/components/sidebar/common/SectionResult.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 import * as notistack from 'notistack';
 import { ListItem, Typography } from '@material-ui/core';
 import * as timeUtils from 'util/time';
-import { mockUseDispatch } from 'util/testing';
+import { mockUseDispatch, testSchedule, testSection } from 'util/testing';
 import { sectionHover, sectionHoverOff } from 'actions';
 import SectionResult from './SectionResult';
 
@@ -16,16 +16,9 @@ describe('SectionResult', () => {
   const enqueueSnackbarMock = jest.fn();
   notistack.useSnackbar.mockReturnValue({ enqueueSnackbar: enqueueSnackbarMock });
 
-  const section = {
-    id: '198732',
-    sectionNumber: 20,
-    topic: 'Section topic...',
-    schedules: [{ location: 'somewhere' }],
-    instructors: ['A prof'],
-  };
   const defaultProps = {
     addSection: () => {},
-    section,
+    section: testSection,
   };
   const message = 'Class successfully added';
 
@@ -39,7 +32,7 @@ describe('SectionResult', () => {
 
   it('renders instructors correctly for multiple instructors', () => {
     const wrapper = shallow(
-      <SectionResult {...defaultProps} section={{ ...section, instructors: ['Prof 1', 'Prof 2'] }} />,
+      <SectionResult {...defaultProps} section={{ ...testSection, instructors: ['Prof 1', 'Prof 2'] }} />,
     );
 
     expect(wrapper.find(Typography).at(4).prop('children')).toEqual(['Prof 1, ', 'Prof 2']);
@@ -52,7 +45,7 @@ describe('SectionResult', () => {
     );
     wrapper.find(ListItem).simulate('click');
 
-    expect(addSectionMock).toHaveBeenCalledWith(section);
+    expect(addSectionMock).toHaveBeenCalledWith(testSection);
   });
 
   it('turns scheduled text to red if section is unscheduled', () => {
@@ -60,13 +53,15 @@ describe('SectionResult', () => {
     timeUtils.isUnscheduled.mockReturnValue(true);
     const unscheduledSection = {
       id: '3',
-      sectionNumber: 21,
-      schedules: [{
-        location: 'Some other building',
-        dow: 'TBA',
-        start: 'TBA',
-        end: 'TBA',
-      }],
+      termId: '111111',
+      schoolId: 'MEAS',
+      subjectId: 'COMP_SCI',
+      courseId: '101-1',
+      name: '',
+      sectionNumber: '21',
+      topic: 'Section topic...',
+      descriptions: [{ name: '', value: '' }],
+      schedules: [testSchedule],
       instructors: ['Ian Horswill', 'Vincent St-Amour'],
     };
     const wrapper = shallow(
@@ -85,7 +80,7 @@ describe('SectionResult', () => {
     const wrapper = shallow(<SectionResult {...defaultProps} />);
     wrapper.find(ListItem).simulate('mouseEnter');
 
-    expect(dispatchMock).toHaveBeenCalledWith(sectionHover(section));
+    expect(dispatchMock).toHaveBeenCalledWith(sectionHover(testSection));
   });
 
   it('dispatches sectionHoverOff on mouse leave', () => {

--- a/src/components/sidebar/common/SectionSelection.test.js
+++ b/src/components/sidebar/common/SectionSelection.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import * as timeUtils from 'util/time';
+import { testSchedule, testSection } from 'util/testing';
 import SectionSelection from './SectionSelection';
 import SectionResult from './SectionResult';
 
@@ -8,31 +9,22 @@ describe('SectionSelection', () => {
   const defaultProps = {
     currentCourseName: 'EECS 101-0',
     sections: [{
+      ...testSection,
       id: '1',
-      sectionNumber: 20,
-      schedules: [{
-        location: 'Some building',
-      }],
-      instructors: ['Jason Hartline'],
+      schedules: [{ ...testSchedule, dow: ['Mo'] }],
     }, {
+      ...testSection,
       id: '2',
-      sectionNumber: 21,
-      schedules: [{
-        location: 'Some other building',
-      }],
-      instructors: ['Ian Horswill', 'Vincent St-Amour'],
+      schedules: [{ ...testSchedule, dow: ['Tu'] }],
     }],
     scheduledSections: [],
     addSection: () => {},
     back: () => {},
   };
   const scheduledSectionsTestData = [{
+    ...testSection,
     id: '1',
-    sectionNumber: 20,
-    schedules: [{
-      location: 'Some building',
-    }],
-    instructors: ['Jason Hartline'],
+    schedules: [{ ...testSchedule, dow: ['Mo'] }],
   }];
 
   beforeEach(() => {

--- a/src/components/sidebar/common/__snapshots__/SectionResult.test.js.snap
+++ b/src/components/sidebar/common/__snapshots__/SectionResult.test.js.snap
@@ -13,7 +13,7 @@ exports[`SectionResult renders correctly 1`] = `
       className="makeStyles-sectionTitle-1"
       variant="h6"
     >
-      Section 20
+      Section 1
     </ForwardRef(WithStyles)>
     <ForwardRef(WithStyles)>
       Section topic...
@@ -22,10 +22,10 @@ exports[`SectionResult renders correctly 1`] = `
       MWF 10 - 12ish
     </ForwardRef(WithStyles)>
     <ForwardRef(WithStyles)>
-      somewhere
+      Somewhere
     </ForwardRef(WithStyles)>
     <ForwardRef(WithStyles)>
-      A prof
+      
     </ForwardRef(WithStyles)>
   </ForwardRef(WithStyles)>
 </ForwardRef(WithStyles)>

--- a/src/components/sidebar/common/__snapshots__/SectionSelection.test.js.snap
+++ b/src/components/sidebar/common/__snapshots__/SectionSelection.test.js.snap
@@ -14,16 +14,39 @@ exports[`SectionSelection renders correctly 1`] = `
       disabled={false}
       section={
         Object {
-          "id": "1",
-          "instructors": Array [
-            "Jason Hartline",
-          ],
-          "schedules": Array [
+          "courseId": "101-1",
+          "descriptions": Array [
             Object {
-              "location": "Some building",
+              "name": "",
+              "value": "",
             },
           ],
-          "sectionNumber": 20,
+          "id": "1",
+          "instructors": Array [
+            "",
+          ],
+          "name": "Introduction to Something",
+          "schedules": Array [
+            Object {
+              "dow": Array [
+                "Mo",
+              ],
+              "end": Object {
+                "hour": 12,
+                "minute": 0,
+              },
+              "location": "Somewhere",
+              "start": Object {
+                "hour": 10,
+                "minute": 30,
+              },
+            },
+          ],
+          "schoolId": "MEAS",
+          "sectionNumber": "1",
+          "subjectId": "COMP_SCI",
+          "termId": "111111",
+          "topic": "Section topic...",
         }
       }
     />
@@ -32,17 +55,39 @@ exports[`SectionSelection renders correctly 1`] = `
       disabled={false}
       section={
         Object {
-          "id": "2",
-          "instructors": Array [
-            "Ian Horswill",
-            "Vincent St-Amour",
-          ],
-          "schedules": Array [
+          "courseId": "101-1",
+          "descriptions": Array [
             Object {
-              "location": "Some other building",
+              "name": "",
+              "value": "",
             },
           ],
-          "sectionNumber": 21,
+          "id": "2",
+          "instructors": Array [
+            "",
+          ],
+          "name": "Introduction to Something",
+          "schedules": Array [
+            Object {
+              "dow": Array [
+                "Tu",
+              ],
+              "end": Object {
+                "hour": 12,
+                "minute": 0,
+              },
+              "location": "Somewhere",
+              "start": Object {
+                "hour": 10,
+                "minute": 30,
+              },
+            },
+          ],
+          "schoolId": "MEAS",
+          "sectionNumber": "1",
+          "subjectId": "COMP_SCI",
+          "termId": "111111",
+          "topic": "Section topic...",
         }
       }
     />

--- a/src/util/prop-types.js
+++ b/src/util/prop-types.js
@@ -1,0 +1,60 @@
+import PropTypes from 'prop-types';
+
+export const schoolPropType = {
+  id: PropTypes.string.isRequired,
+  termId: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export const subjectPropType = {
+  id: PropTypes.string.isRequired,
+  termId: PropTypes.string.isRequired,
+  schoolId: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export const coursePropType = {
+  id: PropTypes.string.isRequired,
+  termId: PropTypes.string.isRequired,
+  schoolId: PropTypes.string.isRequired,
+  subjectId: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+};
+
+export const descriptionPropType = {
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+};
+
+export const schedulePropType = {
+  dow: PropTypes.arrayOf(PropTypes.string).isRequired,
+  start: PropTypes.shape({
+    hour: PropTypes.number.isRequired,
+    minute: PropTypes.number.isRequired,
+  }).isRequired,
+  end: PropTypes.shape({
+    hour: PropTypes.number.isRequired,
+    minute: PropTypes.number.isRequired,
+  }).isRequired,
+  location: PropTypes.string.isRequired,
+};
+
+export const associatedClassPropType = {
+  schedule: PropTypes.shape(schedulePropType).isRequired,
+  type: PropTypes.string.isRequired,
+};
+
+export const sectionPropType = {
+  id: PropTypes.string.isRequired,
+  termId: PropTypes.string.isRequired,
+  schoolId: PropTypes.string.isRequired,
+  subjectId: PropTypes.string.isRequired,
+  courseId: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  sectionNumber: PropTypes.string.isRequired,
+  topic: PropTypes.string.isRequired,
+  descriptions: PropTypes.arrayOf(PropTypes.shape(descriptionPropType)).isRequired,
+  instructors: PropTypes.arrayOf(PropTypes.string).isRequired,
+  schedules: PropTypes.arrayOf(PropTypes.shape(schedulePropType)).isRequired,
+  associatedClasses: PropTypes.arrayOf(PropTypes.shape(associatedClassPropType)),
+};

--- a/src/util/testing.js
+++ b/src/util/testing.js
@@ -31,3 +31,37 @@ export function mockUseDispatch() {
   reactRedux.useDispatch.mockReturnValue(dispatchSpy);
   return dispatchSpy;
 }
+
+// Default test objects
+
+const testDow = ['Mo'];
+
+export const testSchedule = {
+  dow: testDow,
+  start: {
+    hour: 10,
+    minute: 30,
+  },
+  end: {
+    hour: 12,
+    minute: 0,
+  },
+  location: 'Somewhere',
+};
+
+const testName = 'Introduction to Something';
+const testDescription = { name: '', value: '' };
+
+export const testSection = {
+  id: '12345',
+  termId: '111111',
+  schoolId: 'MEAS',
+  subjectId: 'COMP_SCI',
+  courseId: '101-1',
+  name: testName,
+  sectionNumber: '1',
+  topic: 'Section topic...',
+  descriptions: [testDescription],
+  instructors: [''],
+  schedules: [testSchedule],
+};


### PR DESCRIPTION
Previously, we had vague PropType requirements for some of our custom objects such as `section`. This PR implements custom PropTypes for each of our custom objects according to the sans-serif data structure specification.

Doing this broke tests that loosely defined these test custom objects, so this PR also fixes those tests accordingly.