### PR TITLE
Implement undo class removal action on snackbars

### DIFF
--- a/src/components/calendar/AssociatedClass.js
+++ b/src/components/calendar/AssociatedClass.js
@@ -69,6 +69,7 @@ export default function AssociatedClass({ associatedClass, section, isPreview })
         associatedClass={associatedClass}
         showDialog={showDialog}
         toggleDialog={toggleDialog}
+        isAssociatedClass
       />
     </Fragment>
   );

--- a/src/components/calendar/CalendarSection.js
+++ b/src/components/calendar/CalendarSection.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
-import { sectionPropType } from 'util/prop-types';
+import { sectionPropType, associatedClassPropType } from 'util/prop-types';
 import { getFormattedEventTime, getDurationInHours } from 'util/time';
 import Section from 'components/common/Section';
 import ClassModal from './ClassModal';
@@ -43,7 +43,7 @@ export const styles = {
 
 const useStyles = makeStyles(styles);
 
-export default function CalendarSection({ section, isPreview }) {
+export default function CalendarSection({ section, isPreview, associatedClass }) {
   const [showDialog, setShowDialog] = useState(false);
 
   const classes = useStyles({ section, isPreview });
@@ -74,6 +74,7 @@ export default function CalendarSection({ section, isPreview }) {
         section={section}
         showDialog={showDialog}
         toggleDialog={toggleDialog}
+        associatedClass={associatedClass}
       />
     </div>
   );
@@ -82,8 +83,10 @@ export default function CalendarSection({ section, isPreview }) {
 CalendarSection.propTypes = {
   section: PropTypes.shape(sectionPropType).isRequired,
   isPreview: PropTypes.bool,
+  associatedClass: PropTypes.shape(associatedClassPropType),
 };
 
 CalendarSection.defaultProps = {
   isPreview: false,
+  associatedClass: null,
 };

--- a/src/components/calendar/ClassModal.test.js
+++ b/src/components/calendar/ClassModal.test.js
@@ -14,8 +14,8 @@ describe('ClassModal', () => {
   const defaultProps = {
     section,
     showDialog: true,
-    toggleDialog: () => {},
-    removeSection: () => {},
+    toggleDialog: () => { },
+    removeSection: () => { },
   };
   const enqueueSnackbarMock = jest.fn();
   notistack.useSnackbar.mockReturnValue({ enqueueSnackbar: enqueueSnackbarMock });
@@ -46,7 +46,7 @@ describe('ClassModal', () => {
       },
     };
     const wrapper = shallow(
-      <ClassModal {...defaultProps} associatedClass={associatedClass} />,
+      <ClassModal {...defaultProps} associatedClass={associatedClass} isAssociatedClass />,
     );
 
     expect(wrapper.find(DialogTitle).at(0).prop('children'))
@@ -69,8 +69,9 @@ describe('ClassModal', () => {
     );
     wrapper.find(Button).first().simulate('click');
 
-    expect(enqueueSnackbarMock).toHaveBeenCalledWith(message, {
-      variant: 'success',
-    });
+    expect(enqueueSnackbarMock).toHaveBeenCalledWith(message,
+      expect.objectContaining({
+        variant: 'success',
+      }));
   });
 });

--- a/src/components/calendar/HourCell.js
+++ b/src/components/calendar/HourCell.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
 import {
   sectionsSelector,
+  associatedClassSelector,
   sectionsForHourSelector,
   associatedClassesForHourSelector,
   sectionPreviewSelector,
@@ -36,12 +37,24 @@ export default function HourCell({ hour, dow }) {
   );
   const allSections = useSelector(sectionsSelector);
   const allSectionPreviews = useSelector(allSectionPreviewsSelector);
+  const allAssociatedClasses = useSelector(associatedClassSelector);
 
   return (
     <div className={classes.calendarCell}>
-      {sections.map(section => (
-        <CalendarSection key={section.id} section={section} />
-      ))}
+      {sections.map((section) => {
+        const sectionAssociatedClass = allAssociatedClasses.find(
+          associatedClass => associatedClass.sectionId === section.id,
+        );
+        return sectionAssociatedClass
+          ? (
+            <CalendarSection
+              key={section.id}
+              section={section}
+              associatedClass={sectionAssociatedClass}
+            />
+          )
+          : <CalendarSection key={section.id} section={section} />;
+      })}
       {associatedClasses.map(associatedClass => (
         <AssociatedClass
           key={JSON.stringify(associatedClass.event)}

--- a/src/components/calendar/__snapshots__/AssociatedClass.test.js.snap
+++ b/src/components/calendar/__snapshots__/AssociatedClass.test.js.snap
@@ -51,6 +51,7 @@ exports[`AssociatedClass renders correctly 1`] = `
         "type": "LAB",
       }
     }
+    isAssociatedClass={true}
     section={
       Object {
         "courseId": "101-1",

--- a/src/components/calendar/__snapshots__/CalendarSection.test.js.snap
+++ b/src/components/calendar/__snapshots__/CalendarSection.test.js.snap
@@ -18,6 +18,7 @@ exports[`CalendarSection renders correctly 1`] = `
   />
   <ClassModal
     associatedClass={null}
+    isAssociatedClass={false}
     section={
       Object {
         "courseId": "101-1",

--- a/src/components/calendar/__snapshots__/HourCell.test.js.snap
+++ b/src/components/calendar/__snapshots__/HourCell.test.js.snap
@@ -5,6 +5,7 @@ exports[`HourCell renders correctly 1`] = `
   className="makeStyles-calendarCell-1"
 >
   <CalendarSection
+    associatedClass={null}
     isPreview={false}
     section={
       Object {

--- a/src/components/sidebar/cart/__snapshots__/CartSection.test.js.snap
+++ b/src/components/sidebar/cart/__snapshots__/CartSection.test.js.snap
@@ -18,6 +18,7 @@ exports[`CartSection renders correctly 1`] = `
   />
   <ClassModal
     associatedClass={null}
+    isAssociatedClass={false}
     section={
       Object {
         "courseId": "101-1",

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -23,6 +23,10 @@ export function sectionsSelector(state) {
   return state.getIn(['schedule', 'sections']);
 }
 
+export function associatedClassSelector(state) {
+  return state.getIn(['schedule', 'associatedClasses']);
+}
+
 export function sectionsForHourSelector(state, hour, dow) {
   const allSections = state.getIn(['schedule', 'sections']);
   return getMatchingClasses(allSections, hour, dow);


### PR DESCRIPTION
I did pretty much the same thing in terms of the adding the button as undo class addition. For adding back the associated class, I'm not sure if passing it in as a prop is the best way to do it since I had to modify a few other components and add a selector. Let me know what you think!